### PR TITLE
Define Plugin::~Plugin() inline

### DIFF
--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -23,7 +23,7 @@ namespace clap { namespace helpers {
 
    protected:
       Plugin(const clap_plugin_descriptor *desc, const clap_host *host);
-      virtual ~Plugin();
+      virtual ~Plugin() = default;
 
       // not copyable, not moveable
       Plugin(const Plugin &) = delete;

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -131,9 +131,6 @@ namespace clap { namespace helpers {
       _plugin.stop_processing = nullptr;
    }
 
-   template <MisbehaviourHandler h, CheckingLevel l>
-   Plugin<h, l>::~Plugin() = default;
-
    /////////////////////
    // CLAP Interfaces //
    /////////////////////


### PR DESCRIPTION
This change will allow the compiler to create the destructor without needing the template to be explicitly specified.

Essentially it means these lines:

https://github.com/free-audio/clap-examples/blob/main/plugins/core-plugin.cc#L16

aren't needed. 

This gets more complex if the required type might change - as here (which is only two variants, but there could be more):

https://github.com/iPlug2/iPlug2/blob/9845fc59abc0ca72be0aec4fd44152c76aaa10b7/IPlug/CLAP/IPlugCLAP.cpp#L22

Obviously, I can work around this if it stays as it is, but I think this makes things nicer.