### PR TITLE
FindPackage Catch2 in Quiet mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.17)
 cmake_policy(SET CMP0100 NEW)  # handle .hh files
 project(CLAP_HELPERS C CXX)
 enable_testing()
-find_package(Catch2)
+find_package(Catch2 QUIET)
 
 add_library(clap-helpers INTERFACE)
 set_target_properties(clap-helpers PROPERTIES


### PR DESCRIPTION
clap-helpers uses Catch2 for tests; and recovers perfectly
fine if it is not installed. So findpackage it in quiet mode
to avoid splatting a cmake warning when using helpers as a
submodule and so on.