### PR TITLE
Remove filesystem include

### DIFF
--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -1,6 +1,5 @@
 #include <cassert>
 #include <cstring>
-#include <filesystem>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
plugin.hxx includes filesystem but uses no members for it;
some older gcc versions and macos versions dont providle
filesystem even at c++17 so this breaks, for instance,
ubuntu 18 builds. Since it is unused, remove it.