### PR TITLE
Implement note_port extension in the helpers

### DIFF
--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -142,6 +142,16 @@ namespace clap { namespace helpers {
       virtual void quickControlsSelectPage(clap_id pageId) noexcept {}
       virtual clap_id quickControlsSelectedPage() noexcept { return CLAP_INVALID_ID; }
 
+      //------------------------//
+      // clap_plugin_note_ports //
+      //------------------------//
+      virtual bool implementsNotePorts() const noexcept { return false; }
+      virtual uint32_t notePortsCount(bool isInput) const noexcept { return 0; }
+      virtual bool
+      notePortsInfo(uint32_t index, bool isInput, clap_note_port_info *info) const noexcept {
+         return false;
+      }
+
       //-----------------------//
       // clap_plugin_note_name //
       //-----------------------//
@@ -325,6 +335,13 @@ namespace clap { namespace helpers {
       static void clapQuickControlsSelectPage(const clap_plugin *plugin, clap_id page_id) noexcept;
       static clap_id clapQuickControlsSelectedPage(const clap_plugin *plugin) noexcept;
 
+      // clap_plugin_note_port
+      static uint32_t clapNotePortsCount(const clap_plugin *plugin, bool is_input) noexcept;
+      static bool clapNotePortsInfo(const clap_plugin *plugin,
+                                    uint32_t index,
+                                    bool is_input,
+                                    clap_note_port_info *info) noexcept;
+
       // clap_plugin_note_name
       static uint32_t clapNoteNameCount(const clap_plugin *plugin) noexcept;
       static bool clapNoteNameGet(const clap_plugin *plugin,
@@ -375,6 +392,7 @@ namespace clap { namespace helpers {
       static const clap_plugin_params _pluginParams;
       static const clap_plugin_quick_controls _pluginQuickControls;
       static const clap_plugin_latency _pluginLatency;
+      static const clap_plugin_note_ports _pluginNotePorts;
       static const clap_plugin_note_name _pluginNoteName;
       static const clap_plugin_timer_support _pluginTimerSupport;
       static const clap_plugin_posix_fd_support _pluginPosixFdSupport;

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -71,6 +71,10 @@ namespace clap { namespace helpers {
    };
 
    template <MisbehaviourHandler h, CheckingLevel l>
+   const clap_plugin_note_ports Plugin<h, l>::_pluginNotePorts = {clapNotePortsCount,
+                                                                  clapNotePortsInfo};
+
+   template <MisbehaviourHandler h, CheckingLevel l>
    const clap_plugin_note_name Plugin<h, l>::_pluginNoteName = {
       clapNoteNameCount,
       clapNoteNameGet,
@@ -384,6 +388,8 @@ namespace clap { namespace helpers {
          return &_pluginParams;
       if (!strcmp(id, CLAP_EXT_QUICK_CONTROLS) && self.implementQuickControls())
          return &_pluginQuickControls;
+      if (!strcmp(id, CLAP_EXT_NOTE_PORTS) && self.implementsNotePorts())
+         return &_pluginNotePorts;
       if (!strcmp(id, CLAP_EXT_NOTE_NAME) && self.implementsNoteName())
          return &_pluginNoteName;
       if (!strcmp(id, CLAP_EXT_THREAD_POOL) && self.implementsThreadPool())
@@ -829,6 +835,38 @@ namespace clap { namespace helpers {
       self.ensureMainThread("clap_plugin_quick_controls.selected_page");
 
       return self.quickControlsSelectedPage();
+   }
+
+   //------------------------//
+   // clap_plugin_note_ports //
+   //------------------------//
+   template <MisbehaviourHandler h, CheckingLevel l>
+   uint32_t Plugin<h, l>::clapNotePortsCount(const clap_plugin *plugin, bool is_input) noexcept {
+      auto &self = from(plugin);
+      self.ensureMainThread("clap_plugin_note_port.count");
+      return self.notePortsCount(is_input);
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool Plugin<h, l>::clapNotePortsInfo(const clap_plugin *plugin,
+                                        uint32_t index,
+                                        bool is_input,
+                                        clap_note_port_info *info) noexcept {
+      auto &self = from(plugin);
+      self.ensureMainThread("clap_plugin_note_ports.info");
+
+      if (l >= CheckingLevel::Minimal) {
+         auto count = clapNotePortsCount(plugin, is_input);
+         if (index >= count) {
+            std::ostringstream msg;
+            msg << "Host called clap_plugin_note_ports.info() with an index out of bounds: "
+                << index << " >= " << count;
+            self.hostMisbehaving(msg.str());
+            return false;
+         }
+      }
+
+      return self.notePortsInfo(index, is_input, info);
    }
 
    //-----------------------//


### PR DESCRIPTION
Allow C++ clients to advertise note ports properly,
symmetrically with audio ports.