### PR TITLE
Correctly implement Tail in helpers

### DIFF
--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -66,7 +66,14 @@ namespace clap { namespace helpers {
       // clap_plugin_tail //
       //------------------//
       virtual bool implementsTail() const noexcept { return false; }
-      virtual uint32_t tailGet(const clap_plugin_t *plugin) const noexcept { return 0; }
+#ifdef CLAP_HAS_CXX17
+      [[deprecated("Replaced with zero argument version")]]
+#endif
+      virtual uint32_t
+      tailGet(const clap_plugin_t *plugin) const noexcept {
+         return tailGet();
+      }
+      virtual uint32_t tailGet() const noexcept { return 0; }
 
       //--------------------//
       // clap_plugin_render //

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -66,13 +66,6 @@ namespace clap { namespace helpers {
       // clap_plugin_tail //
       //------------------//
       virtual bool implementsTail() const noexcept { return false; }
-#ifdef CLAP_HAS_CXX17
-      [[deprecated("Replaced with zero argument version")]]
-#endif
-      virtual uint32_t
-      tailGet(const clap_plugin_t *plugin) const noexcept {
-         return tailGet();
-      }
       virtual uint32_t tailGet() const noexcept { return 0; }
 
       //--------------------//

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -443,7 +443,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    uint32_t Plugin<h, l>::clapTailGet(const clap_plugin_t *plugin) noexcept {
       auto &self = from(plugin);
-      return self.tailGet(plugin);
+      return self.tailGet();
    }
 
    //--------------------//

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -443,7 +443,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    uint32_t Plugin<h, l>::clapTailGet(const clap_plugin_t *plugin) noexcept {
       auto &self = from(plugin);
-      return self.latencyGet();
+      return self.tailGet(plugin);
    }
 
    //--------------------//


### PR DESCRIPTION
1. Have the tail extension call tailGet not latencyGet
2. Add a correct (no plugin *) signature for tailGet
3. Remain the old (plugin *) signature for subclassers but mark
   it as deprecated