### PR TITLE
Fix canUseThreadCheck not working for checkAudioThread

### DIFF
--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -1368,7 +1368,7 @@ namespace clap { namespace helpers {
       if (l == CheckingLevel::None)
          return;
 
-      if (_host.canUseThreadCheck() || _host.isAudioThread())
+      if (!_host.canUseThreadCheck() || _host.isAudioThread())
          return;
 
       std::terminate();


### PR DESCRIPTION
This PR fixes a bug causing checkAudioThread to call isAudioThread() even if the host doesn't support the CLAP_EXT_THREAD_CHECK extension.