### PR TITLE
Fix C4661 warning on MSVC by adding an empty definition

### DIFF
--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -253,8 +253,8 @@ namespace clap { namespace helpers {
       void runCallbacksOnMainThread();
 
       template <typename T>
-      void initInterface(const T *&ptr, const char *id) noexcept;
-      void initInterfaces() noexcept;
+      void initInterface(const T *&ptr, const char *id) noexcept {};
+      void initInterfaces() noexcept {};
 
       static uint32_t compareAudioPortsInfo(const clap_audio_port_info &a,
                                             const clap_audio_port_info &b) noexcept;


### PR DESCRIPTION
This PR fixes a compiler warning when using MSVC caused by a missing function definition for a template instantiation.