### PR TITLE
Report audio port config extension support to the host

### DIFF
--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -120,6 +120,12 @@ namespace clap { namespace helpers {
       audioPortsInfo(uint32_t index, bool isInput, clap_audio_port_info *info) const noexcept {
          return false;
       }
+       
+      //--------------------------------//
+      // clap_plugin_audio_ports_config //
+      //--------------------------------//
+       
+      virtual bool  implementsAudioPortsConfig() const noexcept { return false; }
       virtual uint32_t audioPortsConfigCount() const noexcept { return 0; }
       virtual bool audioPortsGetConfig(uint32_t index,
                                        clap_audio_ports_config *config) const noexcept {

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -402,6 +402,8 @@ namespace clap { namespace helpers {
          return &_pluginLatency;
       if (!strcmp(id, CLAP_EXT_AUDIO_PORTS) && self.implementsAudioPorts())
          return &_pluginAudioPorts;
+      if (!strcmp(id, CLAP_EXT_AUDIO_PORTS_CONFIG) && self.implementsAudioPortsConfig())
+         return &_pluginAudioPortsConfig;
       if (!strcmp(id, CLAP_EXT_PARAMS) && self.implementsParams())
          return &_pluginParams;
       if (!strcmp(id, CLAP_EXT_QUICK_CONTROLS) && self.implementQuickControls())


### PR DESCRIPTION
 (and add implementsAudioPortsConfig() for consistency)

It looks like this was partially implemented, but not reported to the host, and there was no implementation reporting, so I've tried to make support for this extension consistent with that for audio ports etc.

These are pretty minimal changes, but hopefully should complete what is required here.
