### PR TITLE
Fix copy-paste error 

### DIFF
--- a/include/clap/helpers/host-proxy.hxx
+++ b/include/clap/helpers/host-proxy.hxx
@@ -269,7 +269,7 @@ namespace clap { namespace helpers {
       if (!_hostTail)
          return false;
 
-      if (_hostLatency->changed)
+      if (_hostTail->changed)
          return true;
 
       hostMisbehaving("clap_host_tail is partially implemented");


### PR DESCRIPTION
(should be checking the tail implementation, not latency)

This looks like a fairly clear copy-paste error, where the error checking is looking at the wrong field (concerning latency and not tail).