### PR TITLE
Change Plugin::sampleRate() to return double instead of int

### DIFF
--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -299,7 +299,7 @@ namespace clap { namespace helpers {
       //////////////////////
       bool isActive() const noexcept { return _isActive; }
       bool isProcessing() const noexcept { return _isProcessing; }
-      int sampleRate() const noexcept {
+      double sampleRate() const noexcept {
          assert(_isActive && "sample rate is only known if the plugin is active");
          assert(_sampleRate > 0);
          return _sampleRate;


### PR DESCRIPTION
The member _sampleRate is already a double, and there is no other way to get the original value otherwise.

Fixes #14