### PR TITLE
Integer casting

### DIFF
--- a/include/clap/helpers/event-list.hh
+++ b/include/clap/helpers/event-list.hh
@@ -47,9 +47,9 @@ namespace clap { namespace helpers {
             _events.reserve(_events.capacity() * 2);
 
          auto ptr = _heap.allocate(align, size);
-         _events.push_back(_heap.offsetFromBase(ptr));
+         _events.push_back(static_cast<uint32_t>(_heap.offsetFromBase(ptr)));
          auto hdr = static_cast<clap_event_header *>(ptr);
-         hdr->size = size;
+         hdr->size = static_cast<uint32_t>(size);
          return hdr;
       }
 
@@ -66,9 +66,9 @@ namespace clap { namespace helpers {
          if (!ptr)
             return nullptr;
 
-         _events.push_back(_heap.offsetFromBase(ptr));
+         _events.push_back(static_cast<uint32_t>(_heap.offsetFromBase(ptr)));
          auto hdr = static_cast<clap_event_header *>(ptr);
-         hdr->size = size;
+         hdr->size = static_cast<uint32_t>(size);
          return hdr;
       }
 
@@ -148,7 +148,7 @@ namespace clap { namespace helpers {
    private:
       static uint32_t clapSize(const struct clap_input_events *list) {
          auto *self = static_cast<const EventList *>(list->ctx);
-         return self->size();
+         return static_cast<uint32_t>(self->size());
       }
 
       static const clap_event_header_t *clapGet(const struct clap_input_events *list,

--- a/include/clap/helpers/heap.hh
+++ b/include/clap/helpers/heap.hh
@@ -63,7 +63,7 @@ namespace clap { namespace helpers {
 
       void clear() { _brk = 0; }
 
-      void *tryAllocate(uint32_t align, uint32_t size) {
+      void *tryAllocate(size_t align, size_t size) {
          assert(_brk <= _size);
          void *ptr = _base + _brk;
          size_t space = _size - _brk;
@@ -71,13 +71,13 @@ namespace clap { namespace helpers {
          if (!std::align(align, size, ptr, space))
             return nullptr;
 
-         auto offset = static_cast<uint8_t *>(ptr) - _base;
+         auto offset = static_cast<size_t>(static_cast<uint8_t *>(ptr) - _base);
          _brk = offset + size;
          std::memset(ptr, 0, size);
          return ptr;
       }
 
-      void *allocate(uint32_t align, uint32_t size) {
+      void *allocate(size_t align, size_t size) {
          assert(_brk <= _size);
          if (size + _brk > _size)
             reserve(_size * 2);

--- a/include/clap/helpers/heap.hh
+++ b/include/clap/helpers/heap.hh
@@ -95,7 +95,7 @@ namespace clap { namespace helpers {
 
       size_t offsetFromBase(const void *ptr) const {
          assert(ptr >= _base && "ptr before heap's base");
-         size_t offset = static_cast<const uint8_t *>(ptr) - _base;
+         size_t offset = static_cast<size_t>(static_cast<const uint8_t *>(ptr) - _base);
          assert(offset < _size && "ptr after heap's end");
          return offset;
       }

--- a/include/clap/helpers/host-proxy.hh
+++ b/include/clap/helpers/host-proxy.hh
@@ -128,8 +128,8 @@ namespace clap { namespace helpers {
       // clap_host_fd_support //
       //////////////////////////
       bool canUsePosixFdSupport() const noexcept;
-      bool posixFdSupportRegister(int fd, int flags) const noexcept;
-      bool posixFdSupportModify(int fd, int flags) const noexcept;
+      bool posixFdSupportRegister(int fd, clap_posix_fd_flags_t flags) const noexcept;
+      bool posixFdSupportModify(int fd, clap_posix_fd_flags_t flags) const noexcept;
       bool posixFdSupportUnregister(int fd) const noexcept;
 
       //////////////////////////////

--- a/include/clap/helpers/host-proxy.hxx
+++ b/include/clap/helpers/host-proxy.hxx
@@ -464,14 +464,14 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool HostProxy<h, l>::posixFdSupportRegister(int fd, int flags) const noexcept {
+   bool HostProxy<h, l>::posixFdSupportRegister(int fd, clap_posix_fd_flags_t flags) const noexcept {
       assert(canUsePosixFdSupport());
       ensureMainThread("posix_fd_support.register");
       return _hostPosixFdSupport->register_fd(_host, fd, flags);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool HostProxy<h, l>::posixFdSupportModify(int fd, int flags) const noexcept {
+   bool HostProxy<h, l>::posixFdSupportModify(int fd, clap_posix_fd_flags_t flags) const noexcept {
       assert(canUsePosixFdSupport());
       ensureMainThread("posix_fd_support.modify");
       return _hostPosixFdSupport->modify_fd(_host, fd, flags);

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -208,8 +208,8 @@ namespace clap { namespace helpers {
       // clap_plugin_note_name //
       //-----------------------//
       virtual bool implementsNoteName() const noexcept { return false; }
-      virtual int noteNameCount() noexcept { return 0; }
-      virtual bool noteNameGet(int index, clap_note_name *noteName) noexcept { return false; }
+      virtual uint32_t noteNameCount() noexcept { return 0; }
+      virtual bool noteNameGet(uint32_t index, clap_note_name *noteName) noexcept { return false; }
 
       //---------------------------//
       // clap_plugin_timer_support //

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -221,7 +221,7 @@ namespace clap { namespace helpers {
       // clap_plugin_posix_fd_support //
       //------------------------------//
       virtual bool implementsPosixFdSupport() const noexcept { return false; }
-      virtual void onPosixFd(int fd, int flags) noexcept {}
+      virtual void onPosixFd(int fd, clap_posix_fd_flags_t flags) noexcept {}
 
       //-----------------//
       // clap_plugin_gui //

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -782,7 +782,7 @@ namespace clap { namespace helpers {
          const auto paramIndex = self.getParamIndexForParamId(paramId);
          if (paramIndex >= 0) {
             clap_param_info info;
-            if (clapParamsInfo(&self._plugin, paramIndex, &info) &&
+            if (clapParamsInfo(&self._plugin, static_cast<uint32_t>(paramIndex), &info) &&
                (*value < info.min_value || info.max_value < *value)) {
                   std::ostringstream msg;
                   msg << "clap_plugin_params.value(" << paramId << ") = " << *value << ", is out of range";
@@ -845,7 +845,7 @@ namespace clap { namespace helpers {
                const auto paramIndex = self.getParamIndexForParamId(pev->param_id);
                if (paramIndex != -1) {
                   clap_param_info info;
-                  if (clapParamsInfo(&self._plugin, paramIndex, &info) &&
+                  if (clapParamsInfo(&self._plugin, static_cast<uint32_t>(paramIndex), &info) &&
                       (pev->value < info.min_value || info.max_value < pev->value)) {
                      std::ostringstream msg;
                      msg << "clap_plugin_params.flush() produced the value " << pev->value
@@ -885,7 +885,7 @@ namespace clap { namespace helpers {
             const auto paramIndex = self.getParamIndexForParamId(param_id);
             if (paramIndex != -1) {
                clap_param_info info;
-               if (clapParamsInfo(&self._plugin, paramIndex, &info) &&
+               if (clapParamsInfo(&self._plugin, static_cast<uint32_t>(paramIndex), &info) &&
                    (value < info.min_value || info.max_value < value)) {
                   std::ostringstream msg;
                   msg << "clap_plugin_params.value_to_text() the value " << value
@@ -948,7 +948,7 @@ namespace clap { namespace helpers {
          const auto paramIndex = self.getParamIndexForParamId(param_id);
          if (paramIndex != -1) {
             clap_param_info info;
-            if (clapParamsInfo(&self._plugin, paramIndex, &info) &&
+            if (clapParamsInfo(&self._plugin, static_cast<uint32_t>(paramIndex), &info) &&
                   (*value < info.min_value || info.max_value < *value)) {
                std::ostringstream msg;
                msg << "clap_plugin_params.text_to_value() produced the value " << value
@@ -971,7 +971,7 @@ namespace clap { namespace helpers {
             continue;
 
          if (info.id == param_id)
-            return i;
+            return static_cast<int32_t>(i);
       }
 
       return -1;


### PR DESCRIPTION
This patch changes some of the integer types of the plugin and host APIs to match the integer types in CLAP, and therefore will require people to change their override methods.

Besides that there is some nit-picking about casting integers found using -Wconversion flag in clang.

Up to you if you want to merge this. This level of explicitness about casting does make things a bit verbose.