### PR TITLE
Add support for resource directory

### DIFF
--- a/include/clap/helpers/host-proxy.hh
+++ b/include/clap/helpers/host-proxy.hh
@@ -181,6 +181,13 @@ namespace clap { namespace helpers {
                             const char *location,
                             const char *load_key) const noexcept;
 
+      //////////////////////////////////
+      // clap_host_resource_directory //
+      //////////////////////////////////
+      bool canUseResourceDirectory() const noexcept;
+      bool requestDirectory(bool isShared) const noexcept;
+      void releaseDirectory(bool isShared) const noexcept;
+
    protected:
       void ensureMainThread(const char *method) const noexcept;
       void ensureAudioThread(const char *method) const noexcept;

--- a/include/clap/helpers/host-proxy.hxx
+++ b/include/clap/helpers/host-proxy.hxx
@@ -646,4 +646,33 @@ namespace clap { namespace helpers {
 
       _hostPresetLoad->loaded(_host, location_kind, location, load_key);
    }
+
+   //////////////////////////////////
+   // clap_host_resource_directory //
+   //////////////////////////////////
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool HostProxy<h, l>::canUseResourceDirectory() const noexcept {
+      if (!_hostResourceDirectory)
+         return false;
+
+      if (_hostResourceDirectory->request_directory && _hostResourceDirectory->release_directory)
+         return true;
+
+      hostMisbehaving("clap_host_resource_directory is partially implemented");
+      return false;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool HostProxy<h, l>::requestDirectory(bool isShared) const noexcept {
+      assert(canUseResourceDirectory());
+      ensureMainThread("resource_directory.request_directory");
+      return _hostResourceDirectory->request_directory(_host, isShared);
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   void HostProxy<h, l>::releaseDirectory(bool isShared) const noexcept {
+      assert(canUseResourceDirectory());
+      ensureMainThread("resource_directory.release_directory");
+      _hostResourceDirectory->release_directory(_host, isShared);
+   }
 }} // namespace clap::helpers

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -261,6 +261,19 @@ namespace clap { namespace helpers {
          return false;
       }
 
+      //--------------------------------//
+      // clap_plugin_resource_directory //
+      //--------------------------------//
+      virtual bool implementsResourceDirectory() const noexcept { return false; }
+      virtual void resourceDirectorySetDirectory(const char *path, bool isShared) noexcept {}
+      virtual void resourceDirectoryCollect(bool all) noexcept {}
+      virtual uint32_t resourceDirectoryGetFilesCount() const noexcept { return 0; }
+      virtual int32_t resourceDirectoryGetFilePath(uint32_t index,
+                                                   char *path,
+                                                   uint32_t pathSize) const noexcept {
+         return -1;
+      }
+
       //------------------------//
       // clap_plugin_voice_info //
       //------------------------//
@@ -495,6 +508,17 @@ namespace clap { namespace helpers {
                                          const clap_context_menu_target_t *target,
                                          clap_id action_id) noexcept;
 
+      // clap_plugin_resource_directory
+      static void clapResourceDirectorySetDirectory(const clap_plugin_t *plugin,
+                                                    const char *path,
+                                                    bool is_shared) noexcept;
+      static void clapResourceDirectoryCollect(const clap_plugin_t *plugin, bool all) noexcept;
+      static uint32_t clapResourceDirectoryGetFilesCount(const clap_plugin_t *plugin) noexcept;
+      static int32_t clapResourceDirectoryGetFilePath(const clap_plugin_t *plugin,
+                                                      uint32_t index,
+                                                      char *path,
+                                                      uint32_t path_size) noexcept;
+
       // interfaces
       static const clap_plugin_audio_ports _pluginAudioPorts;
       static const clap_plugin_audio_ports_config _pluginAudioPortsConfig;
@@ -517,6 +541,7 @@ namespace clap { namespace helpers {
       static const clap_plugin_track_info _pluginTrackInfo;
       static const clap_plugin_voice_info _pluginVoiceInfo;
       static const clap_plugin_context_menu _pluginContextMenu;
+      static const clap_plugin_resource_directory _pluginResourceDirectory;
 
       // state
       bool _wasInitialized = false;

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -128,6 +128,14 @@ namespace clap { namespace helpers {
    };
 
    template <MisbehaviourHandler h, CheckingLevel l>
+   const clap_plugin_resource_directory Plugin<h, l>::_pluginResourceDirectory = {
+      clapResourceDirectorySetDirectory,
+      clapResourceDirectoryCollect,
+      clapResourceDirectoryGetFilesCount,
+      clapResourceDirectoryGetFilePath,
+   };
+
+   template <MisbehaviourHandler h, CheckingLevel l>
    const clap_plugin_voice_info Plugin<h, l>::_pluginVoiceInfo = {
       clapVoiceInfoGet,
    };
@@ -472,6 +480,8 @@ namespace clap { namespace helpers {
          return &_pluginTail;
       if (!strcmp(id, CLAP_EXT_CONTEXT_MENU))
          return &_pluginContextMenu;
+      if (!strcmp(id, CLAP_EXT_RESOURCE_DIRECTORY) && self.implementsResourceDirectory())
+         return &_pluginResourceDirectory;
 
       return self.extension(id);
    }
@@ -1580,6 +1590,42 @@ namespace clap { namespace helpers {
       self.ensureMainThread("clap_plugin_context_menu.perform");
 
       return self.contextMenuPerform(target, action_id);
+   }
+
+   //--------------------------------//
+   // clap_plugin_resource_directory //
+   //--------------------------------//
+   template <MisbehaviourHandler h, CheckingLevel l>
+   void Plugin<h, l>::clapResourceDirectorySetDirectory(const clap_plugin_t *plugin,
+                                                        const char *path,
+                                                        bool is_shared) noexcept {
+      auto &self = from(plugin);
+      self.ensureMainThread("clap_plugin_resource_directory.set_directory");
+      self.resourceDirectorySetDirectory(path, is_shared);
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   void Plugin<h, l>::clapResourceDirectoryCollect(const clap_plugin_t *plugin, bool all) noexcept {
+      auto &self = from(plugin);
+      self.ensureMainThread("clap_plugin_resource_directory.collect");
+      self.resourceDirectoryCollect(all);
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   uint32_t Plugin<h, l>::clapResourceDirectoryGetFilesCount(const clap_plugin_t *plugin) noexcept {
+      auto &self = from(plugin);
+      self.ensureMainThread("clap_plugin_resource_directory.get_files_count");
+      return self.resourceDirectoryGetFilesCount();
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   int32_t Plugin<h, l>::clapResourceDirectoryGetFilePath(const clap_plugin_t *plugin,
+                                                          uint32_t index,
+                                                          char *path,
+                                                          uint32_t path_size) noexcept {
+      auto &self = from(plugin);
+      self.ensureMainThread("clap_plugin_resource_directory.get_file_path");
+      return self.resourceDirectoryGetFilePath(index, path, path_size);
    }
 
    /////////////


### PR DESCRIPTION
at least the methods and basic checks are  in place, I think.

Did I forget anything? Are there some more detailed checks that should be performed? E.g. should the plugin check for `_host.canUseResourceDirectory()` inside the `Plugin<h, l>::clapResourceDirectory...` methods?