### PR TITLE
Some more work on PluginProxy

### DIFF
--- a/include/clap/helpers/plugin-proxy.hh
+++ b/include/clap/helpers/plugin-proxy.hh
@@ -92,6 +92,13 @@ namespace clap { namespace helpers {
       bool remoteControlsGet(uint32_t                     pageIndex,
                              clap_remote_controls_page_t *page) const noexcept;
 
+      ////////////////////////
+      // clap_plugin_render //
+      ////////////////////////
+      bool canUseRender() const noexcept;
+      bool renderHasHardRealtimeRequirement() const noexcept;
+      bool renderSet(clap_plugin_render_mode mode) const noexcept;
+
       ///////////////////////
       // clap_plugin_state //
       ///////////////////////
@@ -129,6 +136,7 @@ namespace clap { namespace helpers {
       const clap_plugin_posix_fd_support *_pluginPosixFdSupport = nullptr;
       const clap_plugin_preset_load *_pluginPresetLoad = nullptr;
       const clap_plugin_remote_controls *_pluginRemoteControls = nullptr;
+      const clap_plugin_render *_pluginRender = nullptr;
       const clap_plugin_state *_pluginState = nullptr;
       const clap_plugin_tail *_pluginTail = nullptr;
       const clap_plugin_thread_pool *_pluginThreadPool = nullptr;

--- a/include/clap/helpers/plugin-proxy.hh
+++ b/include/clap/helpers/plugin-proxy.hh
@@ -99,6 +99,12 @@ namespace clap { namespace helpers {
       bool stateSave(const clap_ostream_t *stream) const noexcept;
       bool stateLoad(const clap_istream_t *stream) const noexcept;
 
+      //////////////////////
+      // clap_plugin_tail //
+      //////////////////////
+      bool canUseTail() const noexcept;
+      uint32_t tailGet() const noexcept;
+
       /////////////////////////////
       // clap_plugin_thread_pool //
       /////////////////////////////
@@ -124,6 +130,7 @@ namespace clap { namespace helpers {
       const clap_plugin_preset_load *_pluginPresetLoad = nullptr;
       const clap_plugin_remote_controls *_pluginRemoteControls = nullptr;
       const clap_plugin_state *_pluginState = nullptr;
+      const clap_plugin_tail *_pluginTail = nullptr;
       const clap_plugin_thread_pool *_pluginThreadPool = nullptr;
       const clap_plugin_timer_support *_pluginTimerSupport = nullptr;
    };

--- a/include/clap/helpers/plugin-proxy.hh
+++ b/include/clap/helpers/plugin-proxy.hh
@@ -54,6 +54,13 @@ namespace clap { namespace helpers {
       bool guiShow() const noexcept;
       bool guiHide() const noexcept;
 
+      ///////////////////////////////
+      // clap_plugin_midi_mappings //
+      ///////////////////////////////
+      bool canUseMidiMappings() const noexcept;
+      uint32_t midiMappingsCount() const noexcept;
+      bool midiMappingsGet(uint32_t index, clap_midi_mapping_t *mapping) const noexcept;
+
       ////////////////////////
       // clap_plugin_params //
       ////////////////////////
@@ -132,6 +139,7 @@ namespace clap { namespace helpers {
 
       const clap_plugin_audio_ports *_pluginAudioPorts = nullptr;
       const clap_plugin_gui *_pluginGui = nullptr;
+      const clap_plugin_midi_mappings *_pluginMidiMappings = nullptr;
       const clap_plugin_params *_pluginParams = nullptr;
       const clap_plugin_posix_fd_support *_pluginPosixFdSupport = nullptr;
       const clap_plugin_preset_load *_pluginPresetLoad = nullptr;

--- a/include/clap/helpers/plugin-proxy.hh
+++ b/include/clap/helpers/plugin-proxy.hh
@@ -61,6 +61,15 @@ namespace clap { namespace helpers {
       uint32_t midiMappingsCount() const noexcept;
       bool midiMappingsGet(uint32_t index, clap_midi_mapping_t *mapping) const noexcept;
 
+      ////////////////////////////
+      // clap_plugin_note_ports //
+      ////////////////////////////
+      bool canUseNotePorts() const noexcept;
+      uint32_t notePortsCount(bool is_input) const noexcept;
+      bool notePortsGet(uint32_t               index,
+                        bool                   is_input,
+                        clap_note_port_info_t *info) const noexcept;
+
       ////////////////////////
       // clap_plugin_params //
       ////////////////////////
@@ -140,6 +149,7 @@ namespace clap { namespace helpers {
       const clap_plugin_audio_ports *_pluginAudioPorts = nullptr;
       const clap_plugin_gui *_pluginGui = nullptr;
       const clap_plugin_midi_mappings *_pluginMidiMappings = nullptr;
+      const clap_plugin_note_ports *_pluginNotePorts = nullptr;
       const clap_plugin_params *_pluginParams = nullptr;
       const clap_plugin_posix_fd_support *_pluginPosixFdSupport = nullptr;
       const clap_plugin_preset_load *_pluginPresetLoad = nullptr;

--- a/include/clap/helpers/plugin-proxy.hh
+++ b/include/clap/helpers/plugin-proxy.hh
@@ -14,6 +14,7 @@ namespace clap { namespace helpers {
       /////////////////
       // clap_plugin //
       /////////////////
+      const clap_plugin* clapPlugin() const { return &_plugin; }
       bool init() noexcept;
       template <typename T>
       void getExtension(const T *&ptr, const char *id) const noexcept;

--- a/include/clap/helpers/plugin-proxy.hh
+++ b/include/clap/helpers/plugin-proxy.hh
@@ -16,64 +16,64 @@ namespace clap { namespace helpers {
       /////////////////
       bool init() noexcept;
       template <typename T>
-      void getExtension(const T *&ptr, const char *id) noexcept;
+      void getExtension(const T *&ptr, const char *id) const noexcept;
       void destroy() noexcept;
-      bool activate(double sampleRate, uint32_t minFramesCount, uint32_t maxFramesCount) noexcept;
-      void deactivate() noexcept;
-      bool startProcessing() noexcept;
-      void stopProcessing() noexcept;
-      void reset() noexcept;
-      clap_process_status process(const clap_process_t *process) noexcept;
-      void onMainThread() noexcept;
+      bool activate(double sampleRate, uint32_t minFramesCount, uint32_t maxFramesCount) const noexcept;
+      void deactivate() const noexcept;
+      bool startProcessing() const noexcept;
+      void stopProcessing() const noexcept;
+      void reset() const noexcept;
+      clap_process_status process(const clap_process_t *process) const noexcept;
+      void onMainThread() const noexcept;
 
       /////////////////////////////
       // clap_plugin_audio_ports //
       /////////////////////////////
       bool canUseAudioPorts() const noexcept;
-      uint32_t audioPortsCount(bool isInput) noexcept;
-      bool audioPortsGet(uint32_t index, bool isInput, clap_audio_port_info_t *info) noexcept;
+      uint32_t audioPortsCount(bool isInput) const noexcept;
+      bool audioPortsGet(uint32_t index, bool isInput, clap_audio_port_info_t *info) const noexcept;
 
       /////////////////////
       // clap_plugin_gui //
       /////////////////////
       bool canUseGui() const noexcept;
-      bool guiIsApiSupported(const char *api, bool isFloating) noexcept;
-      bool guiGetPreferredApi(const char **api, bool *isFloating) noexcept;
-      bool guiCreate(const char *api, bool isFloating) noexcept;
-      void guiDestroy() noexcept;
-      bool guiSetScale(double scale) noexcept;
-      bool guiGetSize(uint32_t *width, uint32_t *height) noexcept;
-      bool guiCanResize() noexcept;
-      bool guiGetResizeHints(clap_gui_resize_hints_t *hints) noexcept;
-      bool guiAdjustSize(uint32_t *width, uint32_t *height) noexcept;
-      bool guiSetSize(uint32_t width, uint32_t height) noexcept;
-      bool guiSetParent(const clap_window_t *window) noexcept;
-      bool guiSetTransient(const clap_window_t *window) noexcept;
-      void guiSuggestTitle(const char *title) noexcept;
-      bool guiShow() noexcept;
-      bool guiHide();
+      bool guiIsApiSupported(const char *api, bool isFloating) const noexcept;
+      bool guiGetPreferredApi(const char **api, bool *isFloating) const noexcept;
+      bool guiCreate(const char *api, bool isFloating) const noexcept;
+      void guiDestroy() const noexcept;
+      bool guiSetScale(double scale) const noexcept;
+      bool guiGetSize(uint32_t *width, uint32_t *height) const noexcept;
+      bool guiCanResize() const noexcept;
+      bool guiGetResizeHints(clap_gui_resize_hints_t *hints) const noexcept;
+      bool guiAdjustSize(uint32_t *width, uint32_t *height) const noexcept;
+      bool guiSetSize(uint32_t width, uint32_t height) const noexcept;
+      bool guiSetParent(const clap_window_t *window) const noexcept;
+      bool guiSetTransient(const clap_window_t *window) const noexcept;
+      void guiSuggestTitle(const char *title) const noexcept;
+      bool guiShow() const noexcept;
+      bool guiHide() const noexcept;
 
       ////////////////////////
       // clap_plugin_params //
       ////////////////////////
       bool canUseParams() const noexcept;
-      uint32_t paramsCount() noexcept;
-      bool paramsGetInfo(uint32_t paramIndex, clap_param_info_t *paramInfo) noexcept;
-      bool paramsGetValue(clap_id paramId, double *outValue) noexcept;
+      uint32_t paramsCount() const noexcept;
+      bool paramsGetInfo(uint32_t paramIndex, clap_param_info_t *paramInfo) const noexcept;
+      bool paramsGetValue(clap_id paramId, double *outValue) const noexcept;
       bool paramsValueToText(clap_id paramId,
                              double value,
                              char *outBuffer,
-                             uint32_t outBufferCapacity) noexcept;
+                             uint32_t outBufferCapacity) const noexcept;
       bool paramsTextToValue(clap_id paramId,
                              const char *paramValueText,
-                             double *outValue) noexcept;
-      void paramsFlush(const clap_input_events_t *in, const clap_output_events_t *out) noexcept;
+                             double *outValue) const noexcept;
+      void paramsFlush(const clap_input_events_t *in, const clap_output_events_t *out) const noexcept;
 
       //////////////////////////////////
       // clap_plugin_posix_fd_support //
       //////////////////////////////////
       bool canUsePosixFdSupport() const noexcept;
-      void posixFdSupportOnFd(int fd, clap_posix_fd_flags_t flags) noexcept;
+      void posixFdSupportOnFd(int fd, clap_posix_fd_flags_t flags) const noexcept;
 
       /////////////////////////////
       // clap_plugin_preset_load //
@@ -81,34 +81,34 @@ namespace clap { namespace helpers {
       bool canUsePresetLoad() const noexcept;
       bool presetLoadFromLocation(uint32_t locationKind,
                                   const char *location,
-                                  const char *loadKey);
+                                  const char *loadKey)  const noexcept;
 
       /////////////////////////////////
       // clap_plugin_remote_controls //
       /////////////////////////////////
       bool canUseRemoteControls() const noexcept;
-      uint32_t remoteControlsCount() noexcept;
+      uint32_t remoteControlsCount() const noexcept;
       bool remoteControlsGet(uint32_t                     pageIndex,
-                             clap_remote_controls_page_t *page) noexcept;
+                             clap_remote_controls_page_t *page) const noexcept;
 
       ///////////////////////
       // clap_plugin_state //
       ///////////////////////
       bool canUseState() const noexcept;
-      bool stateSave(const clap_ostream_t *stream) noexcept;
-      bool stateLoad(const clap_istream_t *stream) noexcept;
+      bool stateSave(const clap_ostream_t *stream) const noexcept;
+      bool stateLoad(const clap_istream_t *stream) const noexcept;
 
       /////////////////////////////
       // clap_plugin_thread_pool //
       /////////////////////////////
       bool canUseThreadPool() const noexcept;
-      void threadPoolExec(uint32_t taskIndex) noexcept;
+      void threadPoolExec(uint32_t taskIndex) const noexcept;
 
       ///////////////////////////////
       // clap_plugin_timer_support //
       ///////////////////////////////
       bool canUseTimerSupport() const noexcept;
-      void timerSupportOnTimer(clap_id timerId) noexcept;
+      void timerSupportOnTimer(clap_id timerId) const noexcept;
 
    protected:
       void ensureMainThread(const char *method) const noexcept;

--- a/include/clap/helpers/plugin-proxy.hxx
+++ b/include/clap/helpers/plugin-proxy.hxx
@@ -17,7 +17,7 @@ namespace clap { namespace helpers {
       getExtension(_pluginPosixFdSupport, CLAP_EXT_POSIX_FD_SUPPORT);
       getExtension(_pluginPresetLoad, CLAP_EXT_PRESET_LOAD);
       getExtension(_pluginRemoteControls, CLAP_EXT_REMOTE_CONTROLS);
-      getExtension(_pluginState, CLAP_EXT_PLUGIN_STATE);
+      getExtension(_pluginState, CLAP_EXT_STATE);
       getExtension(_pluginThreadPool, CLAP_EXT_THREAD_POOL);
       getExtension(_pluginTimerSupport, CLAP_EXT_TIMER_SUPPORT);
       return true;

--- a/include/clap/helpers/plugin-proxy.hxx
+++ b/include/clap/helpers/plugin-proxy.hxx
@@ -13,6 +13,7 @@ namespace clap { namespace helpers {
 
       getExtension(_pluginAudioPorts, CLAP_EXT_AUDIO_PORTS);
       getExtension(_pluginGui, CLAP_EXT_GUI);
+      getExtension(_pluginMidiMappings, CLAP_EXT_MIDI_MAPPINGS);
       getExtension(_pluginParams, CLAP_EXT_PARAMS);
       getExtension(_pluginPosixFdSupport, CLAP_EXT_POSIX_FD_SUPPORT);
       getExtension(_pluginPresetLoad, CLAP_EXT_PRESET_LOAD);
@@ -230,6 +231,35 @@ namespace clap { namespace helpers {
       assert(canUseGui());
       ensureMainThread("gui.hide");
       return _pluginGui->hide(&_plugin);
+   }
+
+   ///////////////////////////////
+   // clap_plugin_midi_mappings //
+   ///////////////////////////////
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool PluginProxy<h, l>::canUseMidiMappings() const noexcept {
+      if (!_pluginMidiMappings)
+         return false;
+
+      if (_pluginMidiMappings->count && _pluginMidiMappings->get)
+         return true;
+
+      //pluginMisbehaving("clap_plugin_midi_mappings is partially implemented");
+      return false;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   uint32_t PluginProxy<h, l>::midiMappingsCount() const noexcept {
+      assert(canUseMidiMappings());
+      ensureMainThread("midi_mappings.count");
+      return _pluginMidiMappings->count(&_plugin);
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool PluginProxy<h, l>::midiMappingsGet(uint32_t index, clap_midi_mapping_t *mapping) const noexcept {
+      assert(canUseMidiMappings());
+      ensureMainThread("midi_mappings.get");
+      return _pluginMidiMappings->get(&_plugin, index, mapping);
    }
 
    ////////////////////////

--- a/include/clap/helpers/plugin-proxy.hxx
+++ b/include/clap/helpers/plugin-proxy.hxx
@@ -17,7 +17,9 @@ namespace clap { namespace helpers {
       getExtension(_pluginPosixFdSupport, CLAP_EXT_POSIX_FD_SUPPORT);
       getExtension(_pluginPresetLoad, CLAP_EXT_PRESET_LOAD);
       getExtension(_pluginRemoteControls, CLAP_EXT_REMOTE_CONTROLS);
+      getExtension(_pluginRender, CLAP_EXT_RENDER);
       getExtension(_pluginState, CLAP_EXT_STATE);
+      getExtension(_pluginTail, CLAP_EXT_TAIL);
       getExtension(_pluginThreadPool, CLAP_EXT_THREAD_POOL);
       getExtension(_pluginTimerSupport, CLAP_EXT_TIMER_SUPPORT);
       return true;

--- a/include/clap/helpers/plugin-proxy.hxx
+++ b/include/clap/helpers/plugin-proxy.hxx
@@ -14,6 +14,7 @@ namespace clap { namespace helpers {
       getExtension(_pluginAudioPorts, CLAP_EXT_AUDIO_PORTS);
       getExtension(_pluginGui, CLAP_EXT_GUI);
       getExtension(_pluginMidiMappings, CLAP_EXT_MIDI_MAPPINGS);
+      getExtension(_pluginNotePorts, CLAP_EXT_NOTE_PORTS);
       getExtension(_pluginParams, CLAP_EXT_PARAMS);
       getExtension(_pluginPosixFdSupport, CLAP_EXT_POSIX_FD_SUPPORT);
       getExtension(_pluginPresetLoad, CLAP_EXT_PRESET_LOAD);
@@ -260,6 +261,37 @@ namespace clap { namespace helpers {
       assert(canUseMidiMappings());
       ensureMainThread("midi_mappings.get");
       return _pluginMidiMappings->get(&_plugin, index, mapping);
+   }
+
+   ///////////////////////////////
+   // clap_plugin_note_ports //
+   ///////////////////////////////
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool PluginProxy<h, l>::canUseNotePorts() const noexcept {
+      if (!_pluginNotePorts)
+         return false;
+
+      if (_pluginNotePorts->count && _pluginNotePorts->get)
+         return true;
+
+      //pluginMisbehaving("clap_plugin_note_ports is partially implemented");
+      return false;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   uint32_t PluginProxy<h, l>::notePortsCount(bool isInput) const noexcept {
+      assert(canUseNotePorts());
+      ensureMainThread("note_ports.count");
+      return _pluginNotePorts->count(&_plugin, isInput);
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool PluginProxy<h, l>::notePortsGet(uint32_t               index,
+                                        bool                   isInput,
+                                        clap_note_port_info_t *info) const noexcept {
+      assert(canUseNotePorts());
+      ensureMainThread("note_ports.get");
+      return _pluginNotePorts->get(&_plugin, index, isInput, info);
    }
 
    ////////////////////////

--- a/include/clap/helpers/plugin-proxy.hxx
+++ b/include/clap/helpers/plugin-proxy.hxx
@@ -416,7 +416,7 @@ namespace clap { namespace helpers {
       if (!_pluginRemoteControls)
          return false;
 
-      if (_pluginRemoteControlsState->count && _pluginRemoteControls->get)
+      if (_pluginRemoteControls->count && _pluginRemoteControls->get)
           return true;
 
       //pluginMisbehaving("clap_plugin_remote_controls is partially implemented");
@@ -427,7 +427,7 @@ namespace clap { namespace helpers {
    uint32_t PluginProxy<h, l>::remoteControlsCount() const noexcept {
       assert(canUseRemoteControls());
       ensureMainThread("remote_controls.count");
-      return _pluginRemoteControlsState->count(&_plugin);
+      return _pluginRemoteControls->count(&_plugin);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
@@ -435,7 +435,7 @@ namespace clap { namespace helpers {
                                              clap_remote_controls_page_t *page) const noexcept {
       assert(canUseRemoteControls());
       ensureMainThread("remote_controls.get");
-      return _pluginRemoteControlsState->get(&_plugin, pageIndex, page);
+      return _pluginRemoteControls->get(&_plugin, pageIndex, page);
    }
 
    ////////////////////////
@@ -486,14 +486,14 @@ namespace clap { namespace helpers {
    bool PluginProxy<h, l>::stateSave(const clap_ostream *stream) const noexcept {
       assert(canUseState());
       ensureMainThread("state.save");
-      return _pluginState->save(&_plugin, taskIndex);
+      return _pluginState->save(&_plugin);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
    bool PluginProxy<h, l>::stateLoad(const clap_istream *stream) const noexcept {
       assert(canUseState());
       ensureMainThread("state.load");
-      return _pluginState->load(&_plugin, taskIndex);
+      return _pluginState->load(&_plugin);
    }
 
    //////////////////////
@@ -515,7 +515,7 @@ namespace clap { namespace helpers {
    uint32_t PluginProxy<h, l>::tailGet() const noexcept {
       assert(canUseTail());
       // TODO assert [main-thread, audio-thread]
-      return pluginTail->get(&_plugin);
+      return _pluginTail->get(&_plugin);
    }
 
    /////////////////////////////

--- a/include/clap/helpers/plugin-proxy.hxx
+++ b/include/clap/helpers/plugin-proxy.hxx
@@ -25,7 +25,7 @@ namespace clap { namespace helpers {
 
    template <MisbehaviourHandler h, CheckingLevel l>
    template <typename T>
-   void PluginProxy<h, l>::getExtension(const T *&ptr, const char *id) noexcept {
+   void PluginProxy<h, l>::getExtension(const T *&ptr, const char *id) const noexcept {
       assert(!ptr);
       assert(id);
 
@@ -51,29 +51,29 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    bool PluginProxy<h, l>::activate(double sampleRate,
                               uint32_t minFramesCount,
-                              uint32_t maxFramesCount) noexcept {
+                              uint32_t maxFramesCount) const noexcept {
       return _plugin.activate(&_plugin, sampleRate, minFramesCount, maxFramesCount);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void PluginProxy<h, l>::deactivate() noexcept { _plugin.deactivate(&_plugin); }
+   void PluginProxy<h, l>::deactivate() const noexcept { _plugin.deactivate(&_plugin); }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::startProcessing() noexcept { return _plugin.start_processing(&_plugin); }
+   bool PluginProxy<h, l>::startProcessing() const noexcept { return _plugin.start_processing(&_plugin); }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void PluginProxy<h, l>::stopProcessing() noexcept { _plugin.stop_processing(&_plugin); }
+   void PluginProxy<h, l>::stopProcessing() const noexcept { _plugin.stop_processing(&_plugin); }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void PluginProxy<h, l>::reset() noexcept { _plugin.reset(&_plugin); }
+   void PluginProxy<h, l>::reset() const noexcept { _plugin.reset(&_plugin); }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   clap_process_status PluginProxy<h, l>::process(const clap_process_t *process) noexcept {
+   clap_process_status PluginProxy<h, l>::process(const clap_process_t *process) const noexcept {
       return _plugin.process(&_plugin, process);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void PluginProxy<h, l>::onMainThread() noexcept { _plugin.on_main_thread(&_plugin); }
+   void PluginProxy<h, l>::onMainThread() const noexcept { _plugin.on_main_thread(&_plugin); }
 
    /////////////////////////////
    // clap_plugin_audio_ports //
@@ -91,7 +91,7 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   uint32_t PluginProxy<h, l>::audioPortsCount(bool isInput) noexcept {
+   uint32_t PluginProxy<h, l>::audioPortsCount(bool isInput) const noexcept {
       assert(canUseAudioPorts());
       ensureMainThread("audio_ports.count");
       return _pluginAudioPorts->count(&_plugin, isInput);
@@ -100,7 +100,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    bool PluginProxy<h, l>::audioPortsGet(uint32_t index,
                                    bool isInput,
-                                   clap_audio_port_info_t *info) noexcept {
+                                   clap_audio_port_info_t *info) const noexcept {
       assert(canUseAudioPorts());
       ensureMainThread("audio_ports.get");
       return _pluginAudioPorts->get(&_plugin, index, isInput, info);
@@ -126,105 +126,105 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiIsApiSupported(const char *api, bool isFloating) noexcept {
+   bool PluginProxy<h, l>::guiIsApiSupported(const char *api, bool isFloating) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.is_api_supported");
       return _pluginGui->is_api_supported(&_plugin, api, isFloating);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiGetPreferredApi(const char **api, bool *isFloating) noexcept {
+   bool PluginProxy<h, l>::guiGetPreferredApi(const char **api, bool *isFloating) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.get_preferred_api");
       return _pluginGui->get_preferred_api(&_plugin, api, isFloating);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiCreate(const char *api, bool isFloating) noexcept {
+   bool PluginProxy<h, l>::guiCreate(const char *api, bool isFloating) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.create");
       return _pluginGui->create(&_plugin, api, isFloating);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void PluginProxy<h, l>::guiDestroy() noexcept {
+   void PluginProxy<h, l>::guiDestroy() const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.destroy");
       _pluginGui->destroy(&_plugin);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiSetScale(double scale) noexcept {
+   bool PluginProxy<h, l>::guiSetScale(double scale) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.set_scale");
       return _pluginGui->set_scale(&_plugin, scale);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiGetSize(uint32_t *width, uint32_t *height) noexcept {
+   bool PluginProxy<h, l>::guiGetSize(uint32_t *width, uint32_t *height) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.get_size");
       return _pluginGui->get_size(&_plugin, width, height);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiCanResize() noexcept {
+   bool PluginProxy<h, l>::guiCanResize() const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.can_resize");
       return _pluginGui->can_resize(&_plugin);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiGetResizeHints(clap_gui_resize_hints_t *hints) noexcept {
+   bool PluginProxy<h, l>::guiGetResizeHints(clap_gui_resize_hints_t *hints) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.get_resize_hints");
       return _pluginGui->get_resize_hints(&_plugin, hints);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiAdjustSize(uint32_t *width, uint32_t *height) noexcept {
+   bool PluginProxy<h, l>::guiAdjustSize(uint32_t *width, uint32_t *height) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.adjust_size");
       return _pluginGui->adjust_size(&_plugin, width, height);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiSetSize(uint32_t width, uint32_t height) noexcept {
+   bool PluginProxy<h, l>::guiSetSize(uint32_t width, uint32_t height) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.set_size");
       return _pluginGui->set_size(&_plugin, width, height);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiSetParent(const clap_window_t *window) noexcept {
+   bool PluginProxy<h, l>::guiSetParent(const clap_window_t *window) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.set_parent");
       return _pluginGui->set_parent(&_plugin, window);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiSetTransient(const clap_window_t *window) noexcept {
+   bool PluginProxy<h, l>::guiSetTransient(const clap_window_t *window) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.set_transient");
       return _pluginGui->set_transient(&_plugin, window);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void PluginProxy<h, l>::guiSuggestTitle(const char *title) noexcept {
+   void PluginProxy<h, l>::guiSuggestTitle(const char *title) const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.suggest_title");
       _pluginGui->suggest_title(&_plugin, title);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiShow() noexcept {
+   bool PluginProxy<h, l>::guiShow() const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.show");
       return _pluginGui->show(&_plugin);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::guiHide() {
+   bool PluginProxy<h, l>::guiHide() const noexcept {
       assert(canUseGui());
       ensureMainThread("gui.hide");
       return _pluginGui->hide(&_plugin);
@@ -251,21 +251,21 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   uint32_t PluginProxy<h, l>::paramsCount() noexcept {
+   uint32_t PluginProxy<h, l>::paramsCount() const noexcept {
       assert(canUseParams());
       ensureMainThread("params.count");
       return _pluginParams->count(&_plugin);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::paramsGetInfo(uint32_t paramIndex, clap_param_info_t *paramInfo) noexcept {
+   bool PluginProxy<h, l>::paramsGetInfo(uint32_t paramIndex, clap_param_info_t *paramInfo) const noexcept {
       assert(canUseParams());
       ensureMainThread("params.get_info");
       return _pluginParams->get_info(&_plugin, paramIndex, paramInfo);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::paramsGetValue(clap_id paramId, double *outValue) noexcept {
+   bool PluginProxy<h, l>::paramsGetValue(clap_id paramId, double *outValue) const noexcept {
       assert(canUseParams());
       ensureMainThread("params.get_value");
       return _pluginParams->get_value(&_plugin, paramId, outValue);
@@ -275,7 +275,7 @@ namespace clap { namespace helpers {
    bool PluginProxy<h, l>::paramsValueToText(clap_id paramId,
                                        double value,
                                        char *outBuffer,
-                                       uint32_t outBufferCapacity) noexcept {
+                                       uint32_t outBufferCapacity) const noexcept {
       assert(canUseParams());
       ensureMainThread("params.value_to_text");
       return _pluginParams->value_to_text(&_plugin, paramId, value, outBuffer, outBufferCapacity);
@@ -284,7 +284,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    bool PluginProxy<h, l>::paramsTextToValue(clap_id paramId,
                                        const char *paramValueText,
-                                       double *outValue) noexcept {
+                                       double *outValue) const noexcept {
       assert(canUseParams());
       ensureMainThread("params.text_to_value");
       return _pluginParams->text_to_value(&_plugin, paramId, paramValueText, outValue);
@@ -292,7 +292,7 @@ namespace clap { namespace helpers {
 
    template <MisbehaviourHandler h, CheckingLevel l>
    void PluginProxy<h, l>::paramsFlush(const clap_input_events_t *in,
-                                 const clap_output_events_t *out) noexcept {
+                                 const clap_output_events_t *out) const noexcept {
       assert(canUseParams());
       assert(false); // TODO [active ? audio-thread : main-thread]
       _pluginParams->flush(&_plugin, in, out);
@@ -314,7 +314,7 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void PluginProxy<h, l>::posixFdSupportOnFd(int fd, clap_posix_fd_flags_t flags) noexcept {
+   void PluginProxy<h, l>::posixFdSupportOnFd(int fd, clap_posix_fd_flags_t flags) const noexcept {
       assert(canUsePosixFdSupport());
       ensureMainThread("posix_fd_support.on_fd");
       _pluginPosixFdSupport->on_fd(&_plugin, fd, flags);
@@ -338,7 +338,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    bool PluginProxy<h, l>::presetLoadFromLocation(uint32_t locationKind,
                                                   const char *location,
-                                                  const char *loadKey) noexcept {
+                                                  const char *loadKey) const noexcept {
       assert(canUsePresetLoad());
       ensureMainThread("preset_load.from_location");
       return _pluginPresetLoad->from_location(&_plugin, locationKind, location, loadKey);
@@ -360,7 +360,7 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   uint32_t PluginProxy<h, l>::remoteControlsCount() noexcept {
+   uint32_t PluginProxy<h, l>::remoteControlsCount() const noexcept {
       assert(canUseRemoteControls());
       ensureMainThread("remote_controls.count");
       return _pluginRemoteControlsState->count(&_plugin);
@@ -368,7 +368,7 @@ namespace clap { namespace helpers {
 
    template <MisbehaviourHandler h, CheckingLevel l>
    bool PluginProxy<h, l>::remoteControlsGet(uint32_t                     pageIndex,
-                                             clap_remote_controls_page_t *page) noexcept {
+                                             clap_remote_controls_page_t *page) const noexcept {
       assert(canUseRemoteControls());
       ensureMainThread("remote_controls.get");
       return _pluginRemoteControlsState->get(&_plugin, pageIndex, page);
@@ -390,14 +390,14 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::stateSave(const clap_ostream *stream) noexcept {
+   bool PluginProxy<h, l>::stateSave(const clap_ostream *stream) const noexcept {
       assert(canUseState());
       ensureMainThread("state.save");
       return _pluginState->save(&_plugin, taskIndex);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool PluginProxy<h, l>::stateLoad(const clap_istream *stream) noexcept {
+   bool PluginProxy<h, l>::stateLoad(const clap_istream *stream) const noexcept {
       assert(canUseState());
       ensureMainThread("state.load");
       return _pluginState->load(&_plugin, taskIndex);
@@ -419,7 +419,7 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void PluginProxy<h, l>::threadPoolExec(uint32_t taskIndex) noexcept {
+   void PluginProxy<h, l>::threadPoolExec(uint32_t taskIndex) const noexcept {
       assert(canUseThreadPool());
       _pluginThreadPool->exec(&_plugin, taskIndex);
    }
@@ -440,7 +440,7 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void PluginProxy<h, l>::timerSupportOnTimer(clap_id timerId) noexcept {
+   void PluginProxy<h, l>::timerSupportOnTimer(clap_id timerId) const noexcept {
       assert(canUseTimerSupport());
       ensureMainThread("timer_support.on_timer");
       _pluginTimerSupport->on_timer(&_plugin, timerId);

--- a/include/clap/helpers/plugin-proxy.hxx
+++ b/include/clap/helpers/plugin-proxy.hxx
@@ -403,6 +403,28 @@ namespace clap { namespace helpers {
       return _pluginState->load(&_plugin, taskIndex);
    }
 
+   //////////////////////
+   // clap_plugin_tail //
+   //////////////////////
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool PluginProxy<h, l>::canUseTail() const noexcept {
+      if (!_pluginTail)
+         return false;
+
+      if (_pluginTail->get)
+          return true;
+
+      //pluginMisbehaving("clap_plugin_tail is partially implemented");
+      return false;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   uint32_t PluginProxy<h, l>::tailGet() const noexcept {
+      assert(canUseTail());
+      assert(false); // TODO [main-thread, audio-thread]
+      return pluginTail->get(&_plugin);
+   }
+
    /////////////////////////////
    // clap_plugin_thread_pool //
    /////////////////////////////

--- a/include/clap/helpers/plugin-proxy.hxx
+++ b/include/clap/helpers/plugin-proxy.hxx
@@ -358,7 +358,7 @@ namespace clap { namespace helpers {
    void PluginProxy<h, l>::paramsFlush(const clap_input_events_t *in,
                                  const clap_output_events_t *out) const noexcept {
       assert(canUseParams());
-      assert(false); // TODO [active ? audio-thread : main-thread]
+      // TODO assert [active ? audio-thread : main-thread]
       _pluginParams->flush(&_plugin, in, out);
    }
 
@@ -514,7 +514,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    uint32_t PluginProxy<h, l>::tailGet() const noexcept {
       assert(canUseTail());
-      assert(false); // TODO [main-thread, audio-thread]
+      // TODO assert [main-thread, audio-thread]
       return pluginTail->get(&_plugin);
    }
 
@@ -566,7 +566,7 @@ namespace clap { namespace helpers {
       if (l == CheckingLevel::None)
          return;
 
-      assert(false); // TODO !main-thread -> hostMisbehaving
+      // TODO assert [main-thread], otherwise -> hostMisbehaving
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
@@ -574,6 +574,6 @@ namespace clap { namespace helpers {
       if (l == CheckingLevel::None)
          return;
 
-      assert(false); // TODO !audio-thread -> hostMisbehaving
+      // TODO assert [audio-thread], otherwise -> hostMisbehaving
    }
 }} // namespace clap::helpers

--- a/include/clap/helpers/plugin-proxy.hxx
+++ b/include/clap/helpers/plugin-proxy.hxx
@@ -374,6 +374,35 @@ namespace clap { namespace helpers {
       return _pluginRemoteControlsState->get(&_plugin, pageIndex, page);
    }
 
+   ////////////////////////
+   // clap_plugin_render //
+   ////////////////////////
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool PluginProxy<h, l>::canUseRender() const noexcept {
+      if (!_pluginRender)
+         return false;
+
+      if (_pluginRender->has_hard_realtime_requirement && _pluginRender->set)
+          return true;
+
+      //pluginMisbehaving("clap_plugin_render is partially implemented");
+      return false;     
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool PluginProxy<h, l>::renderHasHardRealtimeRequirement() const noexcept {
+      assert(canUseRender());
+      ensureMainThread("render.has_hard_realtime_requirement");
+      return _pluginRender->has_hard_realtime_requirement(&_plugin);
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool PluginProxy<h, l>::renderSet(clap_plugin_render_mode mode) const noexcept {
+      assert(canUseRender());
+      ensureMainThread("render.set");
+      return _pluginRender->set(&_plugin, mode);
+   }
+
    ///////////////////////
    // clap_plugin_state //
    ///////////////////////


### PR DESCRIPTION
- all methods except init() and destroy() can be const
- getter for raw clap_plugin pointer
- **fix typo CLAP_EXT_PLUGIN_STATE -> CLAP_EXT_STATE**
- add more extensions
  - tail
  - render
  - midi mappings
  - note ports