### PR TITLE
HostProxy: should use clap_host const reference instead of pointer

### DIFF
--- a/include/clap/helpers/host-proxy.hh
+++ b/include/clap/helpers/host-proxy.hh
@@ -11,7 +11,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    class HostProxy {
    public:
-      HostProxy(const clap_host *host);
+      HostProxy(const clap_host &host);
 
       // not copyable, not moveable
       HostProxy(const HostProxy &) = delete;
@@ -21,7 +21,7 @@ namespace clap { namespace helpers {
 
       void init();
 
-      const clap_host *host() const noexcept { return _host; }
+      const clap_host *host() const noexcept { return &_host; }
 
       ///////////////
       // clap_host //
@@ -189,7 +189,7 @@ namespace clap { namespace helpers {
       void ensureMainThread(const char *method) const noexcept;
       void ensureAudioThread(const char *method) const noexcept;
 
-      const clap_host *const _host;
+      const clap_host &const _host;
 
       const clap_host_log *_hostLog = nullptr;
       const clap_host_thread_check *_hostThreadCheck = nullptr;

--- a/include/clap/helpers/host-proxy.hxx
+++ b/include/clap/helpers/host-proxy.hxx
@@ -8,7 +8,7 @@
 
 namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
-   HostProxy<h, l>::HostProxy(const ::clap_host *host) : _host(host) {}
+   HostProxy<h, l>::HostProxy(const ::clap_host &host) : _host(host) {}
 
    template <MisbehaviourHandler h, CheckingLevel l>
    void HostProxy<h, l>::init() {
@@ -39,8 +39,8 @@ namespace clap { namespace helpers {
       assert(!ptr);
       assert(id);
 
-      if (_host->get_extension)
-         ptr = static_cast<const T *>(_host->get_extension(_host, id));
+      if (_host.get_extension)
+         ptr = static_cast<const T *>(_host.get_extension(&_host, id));
    }
 
    ///////////////
@@ -48,17 +48,17 @@ namespace clap { namespace helpers {
    ///////////////
    template <MisbehaviourHandler h, CheckingLevel l>
    void HostProxy<h, l>::requestCallback() noexcept {
-      _host->request_callback(_host);
+      _host.request_callback(&_host);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
    void HostProxy<h, l>::requestRestart() noexcept {
-      _host->request_restart(_host);
+      _host.request_restart(&_host);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
    void HostProxy<h, l>::requestProcess() noexcept {
-      _host->request_process(_host);
+      _host.request_process(&_host);
    }
 
    /////////////

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -31,7 +31,7 @@ namespace clap { namespace helpers {
       const clap_plugin *clapPlugin() noexcept { return &_plugin; }
 
    protected:
-      Plugin(const clap_plugin_descriptor *desc, const clap_host *host);
+      Plugin(const clap_plugin_descriptor *desc, const clap_host &host);
       virtual ~Plugin() = default;
 
       /////////////////////////

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -146,7 +146,7 @@ namespace clap { namespace helpers {
    };
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   Plugin<h, l>::Plugin(const clap_plugin_descriptor *desc, const clap_host *host) : _host(host) {
+   Plugin<h, l>::Plugin(const clap_plugin_descriptor *desc, const clap_host &host) : _host(host) {
       _plugin.plugin_data = this;
       _plugin.desc = desc;
       _plugin.init = Plugin<h, l>::clapInit;


### PR DESCRIPTION
For plugin instantiation, there always has to be a host present. So I think there isn't any case where setting the clap_host member to nullptr would make any sense.

Please correct me if I'm wrong. Always happy to discuss!