### PR TITLE
Host: main & audio thread checks

### DIFF
--- a/include/clap/helpers/host.hh
+++ b/include/clap/helpers/host.hh
@@ -99,7 +99,7 @@ namespace clap { namespace helpers {
       // Thread Checking //
       /////////////////////
       void ensureMainThread(const char *method) const noexcept;
-      void ensureAudioThread(const char *method) const noexcept;
+      void ensureAudioThread(const char *method, bool expectedState = true) const noexcept;
 
       ///////////////
       // Utilities //

--- a/include/clap/helpers/host.hh
+++ b/include/clap/helpers/host.hh
@@ -17,6 +17,12 @@ namespace clap { namespace helpers {
 
       const clap_host *clapHost() const { return &_host; }
 
+      ///////////////////////////
+      // Misbehaviour handling //
+      ///////////////////////////
+      void pluginMisbehaving(const char *msg) const noexcept;
+      void pluginMisbehaving(const std::string &msg) const noexcept { pluginMisbehaving(msg.c_str()); }
+
    protected:
       Host(const char *name, const char *vendor, const char *url, const char *version);
       virtual ~Host() = default;
@@ -82,12 +88,18 @@ namespace clap { namespace helpers {
       virtual void tailChanged() noexcept {}
 
       // clap_host_thread_check
-      virtual bool threadCheckIsMainThread() noexcept = 0;
-      virtual bool threadCheckIsAudioThread() noexcept = 0;
+      virtual bool threadCheckIsMainThread() const noexcept = 0;
+      virtual bool threadCheckIsAudioThread() const noexcept = 0;
 
       // clap_host_thread_pool
       virtual bool implementsThreadPool() const noexcept { return false; }
       virtual bool threadPoolRequestExec(uint32_t numTasks) noexcept { return false; }
+
+      /////////////////////
+      // Thread Checking //
+      /////////////////////
+      void ensureMainThread(const char *method) const noexcept;
+      void ensureAudioThread(const char *method) const noexcept;
 
       ///////////////
       // Utilities //

--- a/include/clap/helpers/host.hxx
+++ b/include/clap/helpers/host.hxx
@@ -261,7 +261,17 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    void Host<h, l>::clapParamsRequestFlush(const clap_host_t *host) noexcept {
       auto &self = from(host);
-      //self.ensure[!audio-thread]("log.log");
+
+      if (l != CheckingLevel::None
+          && threadCheckIsAudioThread())
+      {
+         std::ostringstream msg;
+         msg << "Plugin called the method " << "params.request_flush"
+            << "() on wrong thread! It must not be called on audio thread!";
+         pluginMisbehaving(msg.str());
+         return;
+      }
+
       self.paramsRequestFlush();
    }
 

--- a/include/clap/helpers/host.hxx
+++ b/include/clap/helpers/host.hxx
@@ -261,17 +261,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    void Host<h, l>::clapParamsRequestFlush(const clap_host_t *host) noexcept {
       auto &self = from(host);
-
-      if (l != CheckingLevel::None
-          && threadCheckIsAudioThread())
-      {
-         std::ostringstream msg;
-         msg << "Plugin called the method " << "params.request_flush"
-            << "() on wrong thread! It must not be called on audio thread!";
-         pluginMisbehaving(msg.str());
-         return;
-      }
-
+      self.ensureAudioThread("params.request_flush", false);
       self.paramsRequestFlush();
    }
 
@@ -403,16 +393,16 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void Host<h, l>::ensureAudioThread(const char *method) const noexcept {
+   void Host<h, l>::ensureAudioThread(const char *method, bool expectedState) const noexcept {
       if (l == CheckingLevel::None)
          return;
 
-      if (threadCheckIsAudioThread())
+      if (threadCheckIsAudioThread() == expectedState)
          return;
 
       std::ostringstream msg;
-      msg << "Plugin called the method " << method
-          << "() on wrong thread! It must be called on audio thread!";
+      msg << "Plugin called the method " << method << "() on wrong thread! It must "
+          << (expectedState ? "" : "not ") << "be called on audio thread!";
       pluginMisbehaving(msg.str());
    }
 

--- a/include/clap/helpers/host.hxx
+++ b/include/clap/helpers/host.hxx
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <iostream>
+#include <sstream>
 
 #include "host.hh"
 #include "macros.hh"
@@ -93,6 +94,20 @@ namespace clap { namespace helpers {
            clapRequestCallback,
         } {}
 
+   ///////////////////////////
+   // Misbehaviour handling //
+   ///////////////////////////
+   template <MisbehaviourHandler h, CheckingLevel l>
+   void Host<h, l>::pluginMisbehaving(const char *msg) const noexcept {
+      if (implementsLog())
+         logLog(CLAP_LOG_PLUGIN_MISBEHAVING, msg);
+      else
+         std::cerr << msg << std::endl;
+
+      if (h == MisbehaviourHandler::Terminate)
+         std::terminate();
+   }
+
    /////////////////////
    // CLAP Interfaces //
    /////////////////////
@@ -156,12 +171,14 @@ namespace clap { namespace helpers {
    bool Host<h, l>::clapAudioPortsIsRescanFlagSupported(const clap_host_t *host,
                                                         uint32_t flag) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("audio_ports.is_rescan_flag_supported");
       return self.audioPortsIsRescanFlagSupported(flag);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
    void Host<h, l>::clapAudioPortsRescan(const clap_host_t *host, uint32_t flags) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("audio_ports.rescan");
       self.audioPortsRescan(flags);
    }
 
@@ -206,6 +223,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    void Host<h, l>::clapLatencyChanged(const clap_host_t *host) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("latency.changed");
       self.latencyChanged();
    }
 
@@ -227,6 +245,7 @@ namespace clap { namespace helpers {
    void Host<h, l>::clapParamsRescan(const clap_host_t *host,
                                      clap_param_rescan_flags flags) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("params.rescan");
       self.paramsRescan(flags);
    }
 
@@ -235,12 +254,14 @@ namespace clap { namespace helpers {
                                     clap_id param_id,
                                     clap_param_clear_flags flags) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("params.clear");
       self.paramsClear(param_id, flags);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
    void Host<h, l>::clapParamsRequestFlush(const clap_host_t *host) noexcept {
       auto &self = from(host);
+      //self.ensure[!audio-thread]("log.log");
       self.paramsRequestFlush();
    }
 
@@ -252,6 +273,7 @@ namespace clap { namespace helpers {
                                                  int fd,
                                                  clap_posix_fd_flags_t flags) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("posix_fd_support.register_fd");
       return self.posixFdSupportRegisterFd(fd, flags);
    }
 
@@ -260,12 +282,14 @@ namespace clap { namespace helpers {
                                                int fd,
                                                clap_posix_fd_flags_t flags) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("posix_fd_support.modify_fd");
       return self.posixFdSupportModifyFd(fd, flags);
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
    bool Host<h, l>::clapPosixFdSupportUnregisterFd(const clap_host *host, int fd) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("posix_fd_support.unregister_fd");
       return self.posixFdSupportUnregisterFd(fd);
    }
 
@@ -275,12 +299,14 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    void Host<h, l>::clapRemoteControlsChanged(const clap_host *host) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("remote_controls.changed");
       self.remoteControlsChanged();
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
    void Host<h, l>::clapRemoteControlsSuggestPage(const clap_host *host, clap_id page_id) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("remote_controls.suggest_page");
       self.remoteControlsSuggestPage(page_id);
    }
 
@@ -290,6 +316,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    void Host<h, l>::clapStateMarkDirty(const clap_host *host) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("state.mark_dirty");
       self.stateMarkDirty();
    }
 
@@ -299,6 +326,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    void Host<h, l>::clapTailChanged(const clap_host_t *host) noexcept {
       auto &self = from(host);
+      self.ensureAudioThread("tail.changed");
       self.tailChanged();
    }
 
@@ -310,6 +338,7 @@ namespace clap { namespace helpers {
                                                   uint32_t period_ms,
                                                   clap_id *timer_id) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("timer_support.register_timer");
       return self.timerSupportRegisterTimer(period_ms, timer_id);
    }
 
@@ -317,6 +346,7 @@ namespace clap { namespace helpers {
    bool Host<h, l>::clapTimerSupportUnregisterTimer(const clap_host *host,
                                                     clap_id timer_id) noexcept {
       auto &self = from(host);
+      self.ensureMainThread("timer_support.unregister_timer");
       return self.timerSupportUnregisterTimer(timer_id);
    }
 
@@ -341,7 +371,39 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    bool Host<h, l>::clapThreadPoolRequestExec(const clap_host *host, uint32_t num_tasks) noexcept {
       auto &self = from(host);
+      self.ensureAudioThread("thread_pool.request_exec");
       return self.threadPoolRequestExec(num_tasks);
+   }
+
+   /////////////////////
+   // Thread Checking //
+   /////////////////////
+   template <MisbehaviourHandler h, CheckingLevel l>
+   void Host<h, l>::ensureMainThread(const char *method) const noexcept {
+      if (l == CheckingLevel::None)
+         return;
+
+      if (threadCheckIsMainThread())
+         return;
+
+      std::ostringstream msg;
+      msg << "Plugin called the method " << method
+          << "() on wrong thread! It must be called on main thread!";
+      pluginMisbehaving(msg.str());
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   void Host<h, l>::ensureAudioThread(const char *method) const noexcept {
+      if (l == CheckingLevel::None)
+         return;
+
+      if (threadCheckIsAudioThread())
+         return;
+
+      std::ostringstream msg;
+      msg << "Plugin called the method " << method
+          << "() on wrong thread! It must be called on audio thread!";
+      pluginMisbehaving(msg.str());
    }
 
    ///////////////


### PR DESCRIPTION
- I was not sure how to correctly checking for [thread-safe] so I added those as comments for now
- also had to make both `threadCheckIsMainThread` and `threadCheckIsAudioThread` `const` which makes sense in general but also because otherwise I could not use the thread checking methods inside const member functions
  - I guess not too many people use the host helper classes currently so I think it's OK to change it