### PR TITLE
host.hh: fix build error + missing function specifiers

### DIFF
--- a/include/clap/helpers/host.hh
+++ b/include/clap/helpers/host.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include <clap/clap.h>
 
 #include "checking-level.hh"

--- a/include/clap/helpers/host.hh
+++ b/include/clap/helpers/host.hh
@@ -50,8 +50,8 @@ namespace clap { namespace helpers {
 
       // clap_host_audio_ports
       virtual bool implementsAudioPorts() const noexcept { return false; }
-      bool audioPortsIsRescanFlagSupported(uint32_t flag) noexcept { return false; }
-      void audioPortsRescan(uint32_t flags) noexcept {}
+      virtual bool audioPortsIsRescanFlagSupported(uint32_t flag) noexcept { return false; }
+      virtual void audioPortsRescan(uint32_t flags) noexcept {}
 
       // clap_host_gui
       virtual bool implementsGui() const noexcept { return false; }


### PR DESCRIPTION
- Build error: forgot to include `<string>` which is needed for the  new `pluginMisbehaving` / `hostMisbehaving` methods -> fixed
- Added missing `virtual` function specifiers for the `audio-ports` extension methods