### PR TITLE
add 'host-proxy.hxx' to plugin.hxx

### DIFF
--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <utility>
 
+#include "host-proxy.hxx"
 #include "plugin.hh"
 
 namespace clap { namespace helpers {


### PR DESCRIPTION
Hi folks!

I've made this simple [template for a clap plugin using c++](https://github.com/witte/ClapPluginCppTemplate), and noticed that I need to `#include <clap/helpers/host-proxy.hxx>` before `#include <clap/helpers/plugin.hxx>` to get it to work (see https://github.com/witte/ClapPluginCppTemplate/blob/2a16f03d3fd4f944bf2d42abc0bca8b6218f29e6/src/Plugin.cpp#L2).

This is the compiler error that I get (macbook pro m3, macOS 14.2.1, apple-clang 15.0.0):
```
[1/3 3.5/sec] Building CXX object CMakeFiles/ClapPluginCppTemplate.dir/src/Factory.cpp.o
[2/3 4.9/sec] Building CXX object CMakeFiles/ClapPluginCppTemplate.dir/src/Plugin.cpp.o
[3/3 6.9/sec] Linking CXX CFBundle shared module ClapPluginCppTemplate.clap/Contents/MacOS/ClapPluginCppTemplate
FAILED: ClapPluginCppTemplate.clap/Contents/MacOS/ClapPluginCppTemplate 
: && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk -bundle -Wl,-headerpad_max_install_names  -o ClapPluginCppTemplate.clap/Contents/MacOS/ClapPluginCppTemplate CMakeFiles/ClapPluginCppTemplate.dir/src/Plugin.cpp.o CMakeFiles/ClapPluginCppTemplate.dir/src/Factory.cpp.o   && :
ld: Undefined symbols:
  clap::helpers::HostProxy<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::init(), referenced from:
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapInit(clap_plugin const*) in Plugin.cpp.o
  clap::helpers::HostProxy<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::HostProxy(clap_host const*), referenced from:
      Plugin::Plugin(clap_host const*) in Plugin.cpp.o
      Plugin::Plugin(clap_host const*) in Plugin.cpp.o
  clap::helpers::HostProxy<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::isMainThread() const, referenced from:
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::getParamIndexForParamId(unsigned int) const in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::getParamInfoForParamId(unsigned int, clap_param_info*) const in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::isValidParamId(unsigned int) const in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::ensureMainThread(char const*) const in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::runCallbacksOnMainThread() in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapParamsFlush(clap_plugin const*, clap_input_events const*, clap_output_events const*) in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapParamIndicationSetMapping(clap_plugin const*, unsigned int, bool, clap_color const*, char const*, char const*) in Plugin.cpp.o
      ...
  clap::helpers::HostProxy<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::isAudioThread() const, referenced from:
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::ensureAudioThread(char const*) const in Plugin.cpp.o
  clap::helpers::HostProxy<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::canUseTrackInfo() const, referenced from:
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapTrackInfoChanged(clap_plugin const*) in Plugin.cpp.o
  clap::helpers::HostProxy<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::hostMisbehaving(char const*) const, referenced from:
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapDestroy(clap_plugin const*) in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapDestroy(clap_plugin const*) in Plugin.cpp.o
  clap::helpers::HostProxy<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::canUseThreadCheck() const, referenced from:
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::getParamIndexForParamId(unsigned int) const in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::getParamInfoForParamId(unsigned int, clap_param_info*) const in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::isValidParamId(unsigned int) const in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::ensureMainThread(char const*) const in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::runCallbacksOnMainThread() in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapParamsFlush(clap_plugin const*, clap_input_events const*, clap_output_events const*) in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::ensureAudioThread(char const*) const in Plugin.cpp.o
      ...
  clap::helpers::HostProxy<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::pluginMisbehaving(char const*) const, referenced from:
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::runCallbacksOnMainThread() in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapParamsInfo(clap_plugin const*, unsigned int, clap_param_info*) in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapParamsValue(clap_plugin const*, unsigned int, double*) in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapParamsTextToValue(clap_plugin const*, unsigned int, char const*, double*) in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapParamsFlush(clap_plugin const*, clap_input_events const*, clap_output_events const*) in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapGuiGetSize(clap_plugin const*, unsigned int*, unsigned int*) in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapGuiAdjustSize(clap_plugin const*, unsigned int*, unsigned int*) in Plugin.cpp.o
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::clapGuiAdjustSize(clap_plugin const*, unsigned int*, unsigned int*) in Plugin.cpp.o
      ...
  clap::helpers::HostProxy<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::log(int, char const*) const, referenced from:
      clap::helpers::Plugin<(clap::helpers::MisbehaviourHandler)1, (clap::helpers::CheckingLevel)2>::log(int, char const*) const in Plugin.cpp.o
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
15:42:40: The process "/Users/witte/Qt/Tools/CMake/CMake.app/Contents/bin/cmake" exited with code 1.
Error while building/deploying project ClapPluginCppTemplate (kit: Capt+Qt 6.6.1 macOS)
When executing step "Build"
```

This PR fixes this (assuming that `plugin.hxx` should be self contained). Please let me know if I'm missing something, thanks!