### PR TITLE
add 'clap-helpers' cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_policy(SET CMP0100 NEW)  # handle .hh files
 project(CLAP_HELPERS C CXX)
 
 add_library(clap-helpers INTERFACE)
-target_include_directories(clap-helpers INTERFACE include)
+target_include_directories(clap-helpers SYSTEM INTERFACE include)
 target_link_libraries(clap-helpers INTERFACE clap)
 
 # CLAP_BUILD_TESTS is inherited from clap
@@ -32,3 +32,4 @@ if (${CLAP_BUILD_TESTS})
 endif()
 
 install(DIRECTORY include DESTINATION ".")
+install(FILES "cmake/clap-helpers-config.cmake" DESTINATION "./lib/cmake/clap-helpers")

--- a/cmake/clap-helpers-config.cmake
+++ b/cmake/clap-helpers-config.cmake
@@ -1,0 +1,4 @@
+if (NOT TARGET clap-helpers)
+    add_library(clap-helpers INTERFACE IMPORTED GLOBAL)
+    target_include_directories(clap-helpers SYSTEM INTERFACE "${CMAKE_CURRENT_LIST_DIR}/../../../include")
+endif()


### PR DESCRIPTION
Hey folks, it's me again 😬 

This PR fixes using `clap-helpers` with cmake `FetchContent`. As of today, the helpers can be used if they're installed in the same folder as `clap` itself, but if a user wants to use `FetchContent` some [workarounds need to be made](https://github.com/witte/ClapPluginCppTemplate/blob/2a16f03d3fd4f944bf2d42abc0bca8b6218f29e6/cmake/Dependencies.cmake#L14). The same use is [simpler and more idiomatic to cmake](https://github.com/witte/ClapPluginCppTemplate/blob/3a167ad579442fb4ca01104b0d853b1330ddbf41/cmake/Dependencies.cmake#L1)  with the changes from this PR.

I just made the simplest `.cmake` file I could (much smaller than what [cmake generates if you ask it to](https://gist.github.com/witte/0ce3ae48b7d0d5d09d957c09b884f420)), but if you ever want to have specific versions for `clap-helpers` (separate from `clap` itself) this could be improved.

Also, as per my tests (on macOS/Windows/Ubuntu), these changes don't break existing use of the library.