### PR TITLE
Add Github Action tests; Rework CMake

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -13,10 +13,90 @@ jobs:
     strategy:
       matrix:
         include:
+          - os: windows-latest
+            cmakeargs: -A x64
+            install_ninja: false
+            name: Windows 64bit MSVC
+            exe: .exe
+
+          - os: windows-latest
+            cmakeargs: -A x64 -DCLAP_HELPERS_TESTS_CXX_STANDARD=20
+            install_ninja: false
+            name: Windows 64bit C++20 MSVC
+            exe: .exe
+
+          #- os: windows-latest
+          #  cmakeargs: -GNinja -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+          #  install_ninja: true
+          #  name: Windows gcc/minGW
+          #  exe: .exe
+
+          - os: windows-latest
+            cmakeargs: -GNinja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            install_ninja: true
+            name: Windows clang
+            exe: .exe
+
           - os: ubuntu-latest
-            name: Linux
+            cmakeargs: -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_COMPILER=gcc-11
+            install_ninja: false
+            name: Linux gcc11
+
+          - os: ubuntu-latest
+            cmakeargs: -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12
+            install_ninja: false
+            name: Linux gcc12
+
+          - os: ubuntu-latest
+            cmakeargs: -DCLAP_HELPERS_TESTS_CXX_STANDARD=20 -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12
+            install_ninja: false
+            name: Linux gcc12 C++20
+
+          - os: ubuntu-latest
+            cmakeargs: -DCLAP_HELPERS_TESTS_CXX_STANDARD=23 -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12
+            install_ninja: false
+            name: Linux gcc12 C++23
+
+          - os: macos-latest
+            cmakeargs: -GNinja
+            install_ninja: true
+            name: MacOS Ninja
+
+          - os: macos-latest
+            cmakeargs: -G"Xcode"
+            install_ninja: false
+            name: MacOS Xcode
+
+          - os: macos-latest
+            cmakeargs: -G"Ninja Multi-Config" -DCLAP_HELPERS_TESTS_CXX_STANDARD=20
+            install_ninja: true
+            name: MacOS Ninja Multi C++20
+
+          - os: macos-latest
+            cmakeargs: -G"Unix Makefiles"
+            install_ninja: false
+            name: MacOS Unix Makefiles
 
     steps:
-      - name: Echo
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install Ninja
+        if: ${{ matrix.install_ninja }}
+        uses: seanmiddleditch/gha-setup-ninja@master
+
+      - name: Build project
         run: |
-          echo "Hello World"
+          cmake -S . -B ./build ${{ matrix.cmakeargs }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_HELPERS_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_HELPERS_BUILD_TESTS=TRUE
+          cmake --build ./build --config Debug --target clap-helpers-tests --parallel
+
+      - name: Run Tests
+        shell: bash
+        run: |
+          echo "About to run " ./build/clap-helpers-tests${{ matrix.exe }}
+          ls -l ./build/clap-helpers-tests${{ matrix.exe }}
+          echo "Starting Run"
+          ./build/clap-helpers-tests${{ matrix.exe }}
+          echo "Run complete"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+#vs
+.vs
+out
+
+#clion
+.idea
+cmake-build-*
+
+#baconpaul habit
+ignore/
+#df habit
+build/
+out/
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,56 @@
 cmake_minimum_required(VERSION 3.17)
 cmake_policy(SET CMP0100 NEW)  # handle .hh files
-project(CLAP_HELPERS C CXX)
+project(clap-helpers C CXX)
 
-add_library(clap-helpers INTERFACE)
-target_include_directories(clap-helpers SYSTEM INTERFACE include)
-target_link_libraries(clap-helpers INTERFACE clap)
+option(CLAP_HELPERS_BUILD_TESTS "Build tests for the CLAP Helper" FALSE)
+option(CLAP_HELPERS_DOWNLOAD_DEPENDENCIES "Resolve CLAP Targets with CPM if not defined" FALSE)
 
-# CLAP_BUILD_TESTS is inherited from clap
-if (${CLAP_BUILD_TESTS})
-    enable_testing()
-    find_package(Catch2 3 QUIET)
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE include)
 
-    if (Catch2_FOUND)
-        add_executable(clap-helpers-tests EXCLUDE_FROM_ALL
+if ((NOT TARGET clap) AND ${CLAP_HELPERS_DOWNLOAD_DEPENDENCIES})
+    message(STATUS "${PROJECT_NAME}: Downloading CLAP using CPM")
+
+    message(STATUS "${PROJECT_NAME}: including CPM")
+    include(cmake/external/CPM.cmake)
+    CPMAddPackage(
+            NAME "clap"
+            GITHUB_REPOSITORY "free-audio/clap"
+            GIT_TAG "next"
+            EXCLUDE_FROM_ALL TRUE
+            DOWNLOAD_ONLY TRUE
+            SOURCE_DIR cpm/clap
+    )
+
+    add_subdirectory(${CMAKE_BINARY_DIR}/cpm/clap)
+else()
+    message(FATAL_ERROR "${PROJECT_NAME}: 'clap' is not a target. Set CLAP_HELPERS_DOWNLOAD_DEPENDENCIES or include clap before clap-helpers")
+endif()
+target_link_libraries(${PROJECT_NAME} INTERFACE clap)
+
+if (${CLAP_HELPERS_BUILD_TESTS})
+    if (NOT DEFINED CLAP_HELPERS_TESTS_CXX_STANDARD)
+        message(STATUS "${PROJECT_NAME}: defaulting to c++11")
+        set(CLAP_HELPERS_TESTS_CXX_STANDARD 11)
+    endif()
+
+    if ((NOT TARGET Catch2::Catch2WithMain) AND ${CLAP_HELPERS_DOWNLOAD_DEPENDENCIES})
+        message(STATUS "${PROJECT_NAME}: Downloading Catch2")
+        include(cmake/external/CPM.cmake)
+        CPMAddPackage(
+                NAME "Catch2"
+                GITHUB_REPOSITORY "catchorg/Catch2"
+                GIT_TAG "v3.5.1"
+                EXCLUDE_FROM_ALL TRUE
+                DOWNLOAD_ONLY TRUE
+                SOURCE_DIR cpm/catch2
+        )
+        add_subdirectory(${CMAKE_BINARY_DIR}/cpm/catch2)
+    else()
+        message(FATAL_ERROR "${PROJECT_NAME}: 'Catch2::Catch2WithMain' is not a target. Set CLAP_HELPERS_DOWNLOAD_DEPENDENCIES or include catch2 before clap-helpers")
+    endif()
+
+    add_executable(${PROJECT_NAME}-tests EXCLUDE_FROM_ALL
             tests/hex-encoder.cc
             tests/plugin.cc
             tests/param-queue-tests.cc
@@ -20,15 +58,16 @@ if (${CLAP_BUILD_TESTS})
             tests/main.cc
             tests/preset-discovery-indexer.cc
             tests/preset-discovery-provider.cc
-            tests/preset-discovery-metadata-receiver.cc)
-        set_target_properties(clap-helpers-tests PROPERTIES CXX_STANDARD 11)
-        target_link_libraries(clap-helpers-tests clap-helpers clap Catch2::Catch2WithMain)
-        target_compile_definitions(clap-helpers-tests PUBLIC -DCATCH_CONFIG_PREFIX_ALL)
-        add_test(NAME test-clap-helpers COMMAND clap-helpers-tests)
-        add_dependencies(clap-tests clap-helpers-tests)
-    else()
-        message(STATUS "Catch2 >= 3 isn't found -> disable clap-helpers unit tests")
-    endif()
+            tests/preset-discovery-metadata-receiver.cc
+    )
+    set_target_properties(${PROJECT_NAME}-tests PROPERTIES CXX_STANDARD ${CLAP_HELPERS_TESTS_CXX_STANDARD})
+    target_link_libraries(${PROJECT_NAME}-tests ${PROJECT_NAME} Catch2::Catch2WithMain)
+    target_compile_definitions(${PROJECT_NAME}-tests PUBLIC -DCATCH_CONFIG_PREFIX_ALL)
+
+    add_custom_command(TARGET ${PROJECT_NAME}-tests POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E echo "Relocating $<TARGET_FILE:${PROJECT_NAME}-tests> to ${CMAKE_BINARY_DIR}"
+            COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${PROJECT_NAME}-tests>" "${CMAKE_BINARY_DIR}"
+    )
 endif()
 
 install(DIRECTORY include DESTINATION ".")

--- a/cmake/external/CPM.cmake
+++ b/cmake/external/CPM.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.38.6)
+set(CPM_HASH_SUM "11c3fa5f1ba14f15d31c2fb63dbc8628ee133d81c8d764caad9a8db9e0bacb07")
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/include/clap/helpers/event-list.hh
+++ b/include/clap/helpers/event-list.hh
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <vector>
 #include <functional>
+#include <algorithm>
 
 #include <clap/events.h>
 

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -5,7 +5,6 @@
 #include <mutex>
 #include <queue>
 #include <string>
-#include <string_view>
 #include <vector>
 
 #include <clap/all.h>

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -440,7 +440,11 @@ namespace clap { namespace helpers {
 
       if (!strcmp(id, CLAP_EXT_STATE) && self.implementsState())
          return &_pluginState;
-      if ((!strcmp(id, CLAP_EXT_STATE_CONTEXT) || !strcmp(id, CLAP_EXT_STATE_CONTEXT_COMPAT)) &&
+      if ((!strcmp(id, CLAP_EXT_STATE_CONTEXT)
+#ifdef CLAP_EXT_STATE_CONTEXT_COMPAT
+           || !strcmp(id, CLAP_EXT_STATE_CONTEXT_COMPAT)
+#endif
+           ) &&
           self.implementsStateContext() && self.implementsState())
          return &_pluginStateContext;
       if ((!strcmp(id, CLAP_EXT_PRESET_LOAD) || !strcmp(id, CLAP_EXT_PRESET_LOAD_COMPAT)) &&

--- a/tests/param-queue-tests.cc
+++ b/tests/param-queue-tests.cc
@@ -47,12 +47,12 @@ namespace {
 
       bool failed = false;
 
-      std::thread producer([&queue] {
+      std::thread producer([&queue, N] {
          for (uint32_t i = 0; i < N; ++i)
             queue.push(i);
       });
 
-      std::thread consumer([&queue, &failed] {
+      std::thread consumer([&queue, &failed, N] {
          uint32_t v = 0;
          for (uint32_t i = 0; i < N; ++i) {
             while (!queue.tryPop(v))


### PR DESCRIPTION
- Rework the CMakeLists.txt to allow downloads of CLAP, Catch2, etc...
- Add github actions to test the associated changes
- Fix the C++ code to match the current state of clap next in the compiler matrix