### PR TITLE
Create an Actual Plugin in the Test Set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ if (${CLAP_HELPERS_BUILD_TESTS})
     endif()
 
     add_executable(${PROJECT_NAME}-tests EXCLUDE_FROM_ALL
+            tests/create-an-actual-plugin.cc
             tests/hex-encoder.cc
             tests/plugin.cc
             tests/param-queue-tests.cc

--- a/include/clap/helpers/version-check.hh
+++ b/include/clap/helpers/version-check.hh
@@ -1,0 +1,8 @@
+//
+// Created by Paul Walker on 1/17/24.
+//
+
+#ifndef CLAP_HELPERS_VERSION_CHECK_H
+#define CLAP_HELPERS_VERSION_CHECK_H
+
+#endif // CLAP_HELPERS_VERSION_CHECK_H

--- a/include/clap/helpers/version-check.hh
+++ b/include/clap/helpers/version-check.hh
@@ -1,8 +1,0 @@
-//
-// Created by Paul Walker on 1/17/24.
-//
-
-#ifndef CLAP_HELPERS_VERSION_CHECK_H
-#define CLAP_HELPERS_VERSION_CHECK_H
-
-#endif // CLAP_HELPERS_VERSION_CHECK_H

--- a/tests/create-an-actual-plugin.cc
+++ b/tests/create-an-actual-plugin.cc
@@ -1,0 +1,42 @@
+/*
+ * Actually use plugin.hh / plugin.hxx to create a plugin. Assert that it is constructable
+ */
+
+#include "clap/helpers/plugin.hh"
+#include "clap/helpers/plugin.hxx"
+
+#include <type_traits>
+
+#include <catch2/catch_all.hpp>
+
+struct test_plugin : clap::helpers::Plugin<clap::helpers::MisbehaviourHandler::Terminate,
+                                           clap::helpers::CheckingLevel::Maximal>
+{
+   const clap_plugin_descriptor *getDescription()
+   {
+      static const char *features[] = {CLAP_PLUGIN_FEATURE_INSTRUMENT,
+                                       CLAP_PLUGIN_FEATURE_SYNTHESIZER, nullptr};
+      static clap_plugin_descriptor desc = {CLAP_VERSION,
+                                            "org.free-audio.test-case.plugin",
+                                            "Test Case Plugin",
+                                            "Free Audio",
+                                            "http://cleveraudio.org",
+                                            "",
+                                            "",
+                                            "1.0.0",
+                                            "This is a test only plugin",
+                                            &features[0]};
+      return &desc;
+   }
+
+   test_plugin(const clap_host *host) : clap::helpers::Plugin<clap::helpers::MisbehaviourHandler::Terminate,
+                                                              clap::helpers::CheckingLevel::Maximal>(getDescription(), host) {}
+};
+
+CATCH_TEST_CASE("Create an Actual Plugin")
+{
+   CATCH_SECTION("Test Plugin is Creatable")
+   {
+      CATCH_REQUIRE(std::is_constructible<test_plugin, const clap_host *>::value);
+   }
+}


### PR DESCRIPTION
This simply sublcasses Plugin and makes sure it is constructible, but it means a bigger swath of our
code base is exercised at CI time.