### PR TITLE
A proposal for version check in clap-helpers

### DIFF
--- a/include/clap/helpers/host.hh
+++ b/include/clap/helpers/host.hh
@@ -4,6 +4,8 @@
 
 #include <clap/clap.h>
 
+#include "version-check.hh"
+
 #include "checking-level.hh"
 #include "misbehaviour-handler.hh"
 

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -9,6 +9,8 @@
 
 #include <clap/all.h>
 
+#include "version-check.hh"
+
 #include "checking-level.hh"
 #include "host-proxy.hh"
 #include "misbehaviour-handler.hh"

--- a/include/clap/helpers/version-check.hh
+++ b/include/clap/helpers/version-check.hh
@@ -1,0 +1,21 @@
+#pragma once
+
+/*
+ * Check the clap version against the supported versions for this version of CLAP Helpers.
+ * It defines two clap versions, a min and max version, and static asserts that the CLAP
+ * we are using is in range.
+ *
+ * Workflow wise, if you are about to make clap-helpers incompatible with a version, set
+ * the prior version to max, commit and push, and then move the min to current and max to 2 0 0
+ * again.
+ */
+
+#include "clap/version.h"
+
+#if CLAP_VERSION_LT(1,2,0)
+static_assert(false, "Clap version must be at least 1.2.0")
+#endif
+
+#if CLAP_VERSION_GE(2,0,0)
+   static_assert(false, "Clap version must be at most 1.x")
+#endif


### PR DESCRIPTION
As we more tightly couple clap-helpers and clap versions this header allows us to make an "early" error if the clap versions are incompatible.