### PR TITLE
CLAP_STATE_CONTEXT_COMPAT is not coming

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -58,14 +58,14 @@ jobs:
             name: Linux gcc12 C++23
 
           - os: macos-latest
-            cmakeargs: -GNinja
+            cmakeargs: -GNinja -DCLAP_HELPERS_TESTS_CXX_STANDARD=11
             install_ninja: true
-            name: MacOS Ninja
+            name: MacOS Ninja C++11
 
           - os: macos-latest
-            cmakeargs: -G"Xcode"
+            cmakeargs: -G"Xcode" -DCLAP_HELPERS_TESTS_CXX_STANDARD=14
             install_ninja: false
-            name: MacOS Xcode
+            name: MacOS Xcode C++14
 
           - os: macos-latest
             cmakeargs: -G"Ninja Multi-Config" -DCLAP_HELPERS_TESTS_CXX_STANDARD=20
@@ -73,9 +73,9 @@ jobs:
             name: MacOS Ninja Multi C++20
 
           - os: macos-latest
-            cmakeargs: -G"Unix Makefiles"
+            cmakeargs: -G"Unix Makefiles" -DCLAP_HELPERS_TESTS_CXX_STANDARD=17
             install_ninja: false
-            name: MacOS Unix Makefiles
+            name: MacOS Unix Makefiles C++17
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -38,14 +38,14 @@ jobs:
             exe: .exe
 
           - os: ubuntu-latest
-            cmakeargs: -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_COMPILER=gcc-11
+            cmakeargs: -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_COMPILER=gcc-11 -DCLAP_HELPERS_TESTS_CXX_STANDARD=11
             install_ninja: false
-            name: Linux gcc11
+            name: Linux gcc11 C++ 11
 
           - os: ubuntu-latest
-            cmakeargs: -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12
+            cmakeargs: -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12 -DCLAP_HELPERS_TESTS_CXX+STANDARD=17
             install_ninja: false
-            name: Linux gcc12
+            name: Linux gcc12 C++ 17
 
           - os: ubuntu-latest
             cmakeargs: -DCLAP_HELPERS_TESTS_CXX_STANDARD=20 -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12
@@ -68,14 +68,14 @@ jobs:
             name: MacOS Xcode C++14
 
           - os: macos-latest
-            cmakeargs: -G"Ninja Multi-Config" -DCLAP_HELPERS_TESTS_CXX_STANDARD=20
-            install_ninja: true
-            name: MacOS Ninja Multi C++20
-
-          - os: macos-latest
             cmakeargs: -G"Unix Makefiles" -DCLAP_HELPERS_TESTS_CXX_STANDARD=17
             install_ninja: false
             name: MacOS Unix Makefiles C++17
+
+          - os: macos-latest
+            cmakeargs: -G"Ninja Multi-Config" -DCLAP_HELPERS_TESTS_CXX_STANDARD=20
+            install_ninja: true
+            name: MacOS Ninja Multi C++20
 
     steps:
       - name: Checkout code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ if (${CLAP_HELPERS_BUILD_TESTS})
     if (NOT DEFINED CLAP_HELPERS_TESTS_CXX_STANDARD)
         message(STATUS "${PROJECT_NAME}: defaulting to c++11")
         set(CLAP_HELPERS_TESTS_CXX_STANDARD 11)
+    else()
+        message(STATUS "${PROJECT_NAME}: Using CXX Standard ${CLAP_HELPERS_TESTS_CXX_STANDARD}")
     endif()
 
     if ((NOT TARGET Catch2::Catch2WithMain) AND ${CLAP_HELPERS_DOWNLOAD_DEPENDENCIES})
@@ -65,9 +67,17 @@ if (${CLAP_HELPERS_BUILD_TESTS})
             tests/preset-discovery-provider.cc
             tests/preset-discovery-metadata-receiver.cc
     )
+    set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD ${CLAP_HELPERS_TESTS_CXX_STANDARD})
     set_target_properties(${PROJECT_NAME}-tests PROPERTIES CXX_STANDARD ${CLAP_HELPERS_TESTS_CXX_STANDARD})
     target_link_libraries(${PROJECT_NAME}-tests ${PROJECT_NAME} Catch2::Catch2WithMain)
     target_compile_definitions(${PROJECT_NAME}-tests PUBLIC -DCATCH_CONFIG_PREFIX_ALL)
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(${PROJECT_NAME}-tests
+           PRIVATE
+           -Werror
+        )
+    endif()
 
     add_custom_command(TARGET ${PROJECT_NAME}-tests POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E echo "Relocating $<TARGET_FILE:${PROJECT_NAME}-tests> to ${CMAKE_BINARY_DIR}"

--- a/include/clap/helpers/host.hxx
+++ b/include/clap/helpers/host.hxx
@@ -428,7 +428,7 @@ namespace clap { namespace helpers {
    ///////////////
    template <MisbehaviourHandler h, CheckingLevel l>
    Host<h, l> &Host<h, l>::from(const clap_host *host) noexcept {
-      if constexpr (l >= CheckingLevel::Minimal) {
+      if (l >= CheckingLevel::Minimal) {
          if (!host) CLAP_HELPERS_UNLIKELY {
             std::cerr << "Passed an null host pointer" << std::endl;
             std::terminate();
@@ -436,7 +436,7 @@ namespace clap { namespace helpers {
       }
 
       auto self = static_cast<Host *>(host->host_data);
-      if constexpr (l >= CheckingLevel::Minimal) {
+      if (l >= CheckingLevel::Minimal) {
          if (!self) CLAP_HELPERS_UNLIKELY {
             std::cerr << "Passed an invalid host pointer because the host_data is null"
                       << std::endl;

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -440,12 +440,7 @@ namespace clap { namespace helpers {
 
       if (!strcmp(id, CLAP_EXT_STATE) && self.implementsState())
          return &_pluginState;
-      if ((!strcmp(id, CLAP_EXT_STATE_CONTEXT)
-#ifdef CLAP_EXT_STATE_CONTEXT_COMPAT
-           || !strcmp(id, CLAP_EXT_STATE_CONTEXT_COMPAT)
-#endif
-           ) &&
-          self.implementsStateContext() && self.implementsState())
+      if (!strcmp(id, CLAP_EXT_STATE_CONTEXT) && self.implementsStateContext() && self.implementsState())
          return &_pluginStateContext;
       if ((!strcmp(id, CLAP_EXT_PRESET_LOAD) || !strcmp(id, CLAP_EXT_PRESET_LOAD_COMPAT)) &&
           self.implementsPresetLoad())


### PR DESCRIPTION
Helpers referenced it; and I had if-defed it. But it seems that 1.2.0 / next will have a CONTEXT breaking change so will not define a compat. Take out the ifdef.

add 11 and 14 and 17 explicit tests