### PR TITLE
Context Menu Builder still referred to draft/ location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ if (${CLAP_HELPERS_BUILD_TESTS})
     endif()
 
     add_executable(${PROJECT_NAME}-tests EXCLUDE_FROM_ALL
+            tests/context-menu-builder-compiles.cc
             tests/create-an-actual-host.cc
             tests/create-an-actual-plugin.cc
             tests/hex-encoder.cc

--- a/include/clap/helpers/context-menu-builder.hh
+++ b/include/clap/helpers/context-menu-builder.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <clap/ext/draft/context-menu.h>
+#include <clap/ext/context-menu.h>
 
 namespace clap { namespace helpers {
 

--- a/tests/context-menu-builder-compiles.cc
+++ b/tests/context-menu-builder-compiles.cc
@@ -1,0 +1,24 @@
+#include <clap/helpers/context-menu-builder.hh>
+
+#include <type_traits>
+#include <catch2/catch_all.hpp>
+
+namespace {
+
+   struct TestBuilder : clap::helpers::ContextMenuBuilder {
+      TestBuilder() {}
+      bool addItem(clap_context_menu_item_kind_t item_kind, const void *item_data) override
+      {
+         return false;
+      }
+      bool supports(clap_context_menu_item_kind_t item_kind) const noexcept override
+      {
+         return false;
+      }
+   };
+
+   CATCH_TEST_CASE("Context Menu Builder exists") {
+      CATCH_REQUIRE(std::is_constructible<TestBuilder>::value);
+   }
+
+} // namespace


### PR DESCRIPTION
The context menu still refered to context-menu include with
 a draft and our test suite didn't exercise it, so the code
doens't build against 1.2.0

Fix both the include and add a test