### PR TITLE
Extension-specific proxy interfaces

### DIFF
--- a/include/clap/helpers/host-proxy.hh
+++ b/include/clap/helpers/host-proxy.hh
@@ -8,8 +8,215 @@
 #include "misbehaviour-handler.hh"
 
 namespace clap { namespace helpers {
+   // clap_host_log
    template <MisbehaviourHandler h, CheckingLevel l>
-   class HostProxy {
+   class HostLogProxy {
+   public:
+      virtual bool canUseHostLog() const noexcept = 0;
+      virtual void log(clap_log_severity severity, const char *msg) const noexcept = 0;
+   };
+
+   // clap_host_thread_check
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostThreadCheckProxy {
+   public:
+      virtual bool canUseThreadCheck() const noexcept = 0;
+      virtual bool isMainThread() const noexcept = 0;
+      virtual bool isAudioThread() const noexcept = 0;
+   };
+
+   // clap_host_audio_ports_config
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostAudioPortsConfigProxy {
+   public:
+      virtual bool canUseAudioPortsConfig() const noexcept = 0;
+      virtual void audioPortsConfigRescan() const noexcept = 0;
+   };
+
+   // clap_host_audio_ports
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostAudioPortsProxy {
+   public:
+      virtual bool canUseAudioPorts() const noexcept = 0;
+      virtual void audioPortsRescan(uint32_t flags) const noexcept = 0;
+   };
+
+   // clap_host_note_ports
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostNotePortsProxy {
+   public:
+      virtual bool canUseNotePorts() const noexcept = 0;
+      virtual void notePortsRescan(uint32_t flags) const noexcept = 0;
+   };
+
+   // clap_host_state
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostStateProxy {
+   public:
+      virtual bool canUseState() const noexcept = 0;
+      virtual void stateMarkDirty() const noexcept = 0;
+   };
+
+   // clap_host_latency
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostLatencyProxy {
+   public:
+      virtual bool canUseLatency() const noexcept = 0;
+      virtual void latencyChanged() const noexcept = 0;
+   };
+
+   // clap_host_tail
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostTailProxy {
+   public:
+      virtual bool canUseTail() const noexcept = 0;
+      virtual void tailChanged() const noexcept = 0;
+   };
+
+   // clap_host_note_name
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostNoteNameProxy {
+   public:
+      virtual bool canUseNoteName() const noexcept = 0;
+      virtual void noteNameChanged() const noexcept = 0;
+   };
+
+   // clap_host_params
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostParamsProxy {
+   public:
+      virtual bool canUseParams() const noexcept = 0;
+      virtual void paramsRescan(clap_param_rescan_flags flags) const noexcept = 0;
+      virtual void paramsClear(clap_id param_id, clap_param_clear_flags flags) const noexcept = 0;
+      virtual void paramsRequestFlush() const noexcept = 0;
+   };
+
+   // clap_host_track_info
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostTrackInfoProxy {
+   public:
+      virtual bool canUseTrackInfo() const noexcept = 0;
+      virtual bool trackInfoGet(clap_track_info *info) const noexcept = 0;
+   };
+
+   // clap_host_gui
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostGuiProxy {
+   public:
+      virtual bool canUseGui() const noexcept = 0;
+      virtual void guiResizeHintsChanged() const noexcept = 0;
+      virtual bool guiRequestResize(uint32_t width, uint32_t height) const noexcept = 0;
+      virtual bool guiRequestShow() const noexcept = 0;
+      virtual bool guiRequestHide() const noexcept = 0;
+      virtual void guiClosed(bool wasDestroyed) const noexcept = 0;
+   };
+
+   // clap_host_timer_support
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostTimerSupportProxy {
+   public:
+      virtual bool canUseTimerSupport() const noexcept = 0;
+      virtual bool timerSupportRegister(uint32_t period_ms, clap_id *timer_id) const noexcept = 0;
+      virtual bool timerSupportUnregister(clap_id timer_id) const noexcept = 0;
+   };
+
+   // clap_host_fd_support
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostPosixFdSupportProxy {
+   public:
+      virtual bool canUsePosixFdSupport() const noexcept = 0;
+      virtual bool posixFdSupportRegister(int fd, clap_posix_fd_flags_t flags) const noexcept = 0;
+      virtual bool posixFdSupportModify(int fd, clap_posix_fd_flags_t flags) const noexcept = 0;
+      virtual bool posixFdSupportUnregister(int fd) const noexcept = 0;
+   };
+
+   // clap_host_remote_controls
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostRemoteControlsProxy {
+   public:
+      virtual bool canUseRemoteControls() const noexcept = 0;
+      virtual void remoteControlsChanged() const noexcept = 0;
+      virtual void remoteControlsSuggestPage(clap_id page_id) const noexcept = 0;
+   };
+
+   // clap_host_thread_pool
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostThreadPoolProxy {
+   public:
+      virtual bool canUseThreadPool() const noexcept = 0;
+      virtual bool threadPoolRequestExec(uint32_t numTasks) const noexcept = 0;
+   };
+
+   // clap_host_voice_info
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostVoiceInfoProxy {
+   public:
+      virtual bool canUseVoiceInfo() const noexcept = 0;
+      virtual void voiceInfoChanged() const noexcept = 0;
+   };
+
+   // clap_host_context_menu
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostContextMenuProxy {
+   public:
+      virtual bool canUseContextMenu() const noexcept = 0;
+      virtual bool
+      contextMenuPopulate(const clap_context_menu_target_t *target,
+                          const clap_context_menu_builder_t *builder) const noexcept = 0;
+      virtual bool contextMenuPerform(const clap_context_menu_target_t *target,
+                                      clap_id action_id) const noexcept = 0;
+      virtual bool contextMenuCanPopup() const noexcept = 0;
+      virtual bool contextMenuPopup(const clap_context_menu_target_t *target,
+                                    int32_t screen_index,
+                                    int32_t x,
+                                    int32_t y) const noexcept = 0;
+   };
+
+   // clap_host_preset_load
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostPresetLoadProxy {
+   public:
+      virtual bool canUsePresetLoad() const noexcept = 0;
+      virtual void presetLoadOnError(uint32_t location_kind,
+                                     const char *location,
+                                     const char *load_key,
+                                     int32_t os_error,
+                                     const char *msg) const noexcept = 0;
+      virtual void presetLoadLoaded(uint32_t location_kind,
+                                    const char *location,
+                                    const char *load_key) const noexcept = 0;
+   };
+
+   // clap_host_resource_directory
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostResourceDirectoryProxy {
+   public:
+      virtual bool canUseResourceDirectory() const noexcept = 0;
+      virtual bool requestDirectory(bool isShared) const noexcept = 0;
+      virtual void releaseDirectory(bool isShared) const noexcept = 0;
+   };
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class HostProxy : public HostLogProxy<h, l>,
+                     public HostThreadCheckProxy<h, l>,
+                     public HostAudioPortsConfigProxy<h, l>,
+                     public HostAudioPortsProxy<h, l>,
+                     public HostNotePortsProxy<h, l>,
+                     public HostStateProxy<h, l>,
+                     public HostLatencyProxy<h, l>,
+                     public HostTailProxy<h, l>,
+                     public HostNoteNameProxy<h, l>,
+                     public HostParamsProxy<h, l>,
+                     public HostTrackInfoProxy<h, l>,
+                     public HostGuiProxy<h, l>,
+                     public HostTimerSupportProxy<h, l>,
+                     public HostPosixFdSupportProxy<h, l>,
+                     public HostRemoteControlsProxy<h, l>,
+                     public HostThreadPoolProxy<h, l>,
+                     public HostVoiceInfoProxy<h, l>,
+                     public HostContextMenuProxy<h, l>,
+                     public HostPresetLoadProxy<h, l>,
+                     public HostResourceDirectoryProxy<h, l> {
    public:
       HostProxy(const clap_host *host);
 
@@ -35,8 +242,8 @@ namespace clap { namespace helpers {
       ///////////////////
       // clap_host_log //
       ///////////////////
-      bool canUseHostLog() const noexcept;
-      void log(clap_log_severity severity, const char *msg) const noexcept;
+      bool canUseHostLog() const noexcept override;
+      void log(clap_log_severity severity, const char *msg) const noexcept override;
       void hostMisbehaving(const char *msg) const noexcept;
       void hostMisbehaving(const std::string &msg) const noexcept { hostMisbehaving(msg.c_str()); }
       void pluginMisbehaving(const char *msg) const noexcept;
@@ -47,143 +254,143 @@ namespace clap { namespace helpers {
       ////////////////////////////
       // clap_host_thread_check //
       ////////////////////////////
-      bool canUseThreadCheck() const noexcept;
-      bool isMainThread() const noexcept;
-      bool isAudioThread() const noexcept;
+      bool canUseThreadCheck() const noexcept override;
+      bool isMainThread() const noexcept override;
+      bool isAudioThread() const noexcept override;
 
       //////////////////////////////////
       // clap_host_audio_ports_config //
       //////////////////////////////////
-      bool canUseAudioPortsConfig() const noexcept;
-      void audioPortsConfigRescan() const noexcept;
+      bool canUseAudioPortsConfig() const noexcept override;
+      void audioPortsConfigRescan() const noexcept override;
 
       ///////////////////////////
       // clap_host_audio_ports //
       ///////////////////////////
-      bool canUseAudioPorts() const noexcept;
-      void audioPortsRescan(uint32_t flags) const noexcept;
+      bool canUseAudioPorts() const noexcept override;
+      void audioPortsRescan(uint32_t flags) const noexcept override;
 
       //////////////////////////
       // clap_host_note_ports //
       //////////////////////////
-      bool canUseNotePorts() const noexcept;
-      void notePortsRescan(uint32_t flags) const noexcept;
+      bool canUseNotePorts() const noexcept override;
+      void notePortsRescan(uint32_t flags) const noexcept override;
 
       /////////////////////
       // clap_host_state //
       /////////////////////
-      bool canUseState() const noexcept;
-      void stateMarkDirty() const noexcept;
+      bool canUseState() const noexcept override;
+      void stateMarkDirty() const noexcept override;
 
       ///////////////////////
       // clap_host_latency //
       ///////////////////////
-      bool canUseLatency() const noexcept;
-      void latencyChanged() const noexcept;
+      bool canUseLatency() const noexcept override;
+      void latencyChanged() const noexcept override;
 
       ////////////////////
       // clap_host_tail //
       ////////////////////
-      bool canUseTail() const noexcept;
-      void tailChanged() const noexcept;
+      bool canUseTail() const noexcept override;
+      void tailChanged() const noexcept override;
 
       /////////////////////////
       // clap_host_note_name //
       /////////////////////////
-      bool canUseNoteName() const noexcept;
-      void noteNameChanged() const noexcept;
+      bool canUseNoteName() const noexcept override;
+      void noteNameChanged() const noexcept override;
 
       //////////////////////
       // clap_host_params //
       //////////////////////
-      bool canUseParams() const noexcept;
-      void paramsRescan(clap_param_rescan_flags flags) const noexcept;
-      void paramsClear(clap_id param_id, clap_param_clear_flags flags) const noexcept;
-      void paramsRequestFlush() const noexcept;
+      bool canUseParams() const noexcept override;
+      void paramsRescan(clap_param_rescan_flags flags) const noexcept override;
+      void paramsClear(clap_id param_id, clap_param_clear_flags flags) const noexcept override;
+      void paramsRequestFlush() const noexcept override;
 
       //////////////////////////
       // clap_host_track_info //
       //////////////////////////
-      bool canUseTrackInfo() const noexcept;
-      bool trackInfoGet(clap_track_info *info) const noexcept;
+      bool canUseTrackInfo() const noexcept override;
+      bool trackInfoGet(clap_track_info *info) const noexcept override;
 
       ///////////////////
       // clap_host_gui //
       ///////////////////
-      bool canUseGui() const noexcept;
-      void guiResizeHintsChanged() const noexcept;
-      bool guiRequestResize(uint32_t width, uint32_t height) const noexcept;
-      bool guiRequestShow() const noexcept;
-      bool guiRequestHide() const noexcept;
-      void guiClosed(bool wasDestroyed) const noexcept;
+      bool canUseGui() const noexcept override;
+      void guiResizeHintsChanged() const noexcept override;
+      bool guiRequestResize(uint32_t width, uint32_t height) const noexcept override;
+      bool guiRequestShow() const noexcept override;
+      bool guiRequestHide() const noexcept override;
+      void guiClosed(bool wasDestroyed) const noexcept override;
 
       /////////////////////////////
       // clap_host_timer_support //
       /////////////////////////////
-      bool canUseTimerSupport() const noexcept;
-      bool timerSupportRegister(uint32_t period_ms, clap_id *timer_id) const noexcept;
-      bool timerSupportUnregister(clap_id timer_id) const noexcept;
+      bool canUseTimerSupport() const noexcept override;
+      bool timerSupportRegister(uint32_t period_ms, clap_id *timer_id) const noexcept override;
+      bool timerSupportUnregister(clap_id timer_id) const noexcept override;
 
       //////////////////////////
       // clap_host_fd_support //
       //////////////////////////
-      bool canUsePosixFdSupport() const noexcept;
-      bool posixFdSupportRegister(int fd, clap_posix_fd_flags_t flags) const noexcept;
-      bool posixFdSupportModify(int fd, clap_posix_fd_flags_t flags) const noexcept;
-      bool posixFdSupportUnregister(int fd) const noexcept;
+      bool canUsePosixFdSupport() const noexcept override;
+      bool posixFdSupportRegister(int fd, clap_posix_fd_flags_t flags) const noexcept override;
+      bool posixFdSupportModify(int fd, clap_posix_fd_flags_t flags) const noexcept override;
+      bool posixFdSupportUnregister(int fd) const noexcept override;
 
       //////////////////////////////
       // clap_host_remote_controls //
       //////////////////////////////
-      bool canUseRemoteControls() const noexcept;
-      void remoteControlsChanged() const noexcept;
-      void remoteControlsSuggestPage(clap_id page_id) const noexcept;
+      bool canUseRemoteControls() const noexcept override;
+      void remoteControlsChanged() const noexcept override;
+      void remoteControlsSuggestPage(clap_id page_id) const noexcept override;
 
       ///////////////////////////
       // clap_host_thread_pool //
       ///////////////////////////
-      bool canUseThreadPool() const noexcept;
-      bool threadPoolRequestExec(uint32_t numTasks) const noexcept;
+      bool canUseThreadPool() const noexcept override;
+      bool threadPoolRequestExec(uint32_t numTasks) const noexcept override;
 
       //////////////////////////
       // clap_host_voice_info //
       //////////////////////////
-      bool canUseVoiceInfo() const noexcept;
-      void voiceInfoChanged() const noexcept;
+      bool canUseVoiceInfo() const noexcept override;
+      void voiceInfoChanged() const noexcept override;
 
       ////////////////////////////
       // clap_host_context_menu //
       ////////////////////////////
-      bool canUseContextMenu() const noexcept;
+      bool canUseContextMenu() const noexcept override;
       bool contextMenuPopulate(const clap_context_menu_target_t *target,
-                               const clap_context_menu_builder_t *builder) const noexcept;
+                               const clap_context_menu_builder_t *builder) const noexcept override;
       bool contextMenuPerform(const clap_context_menu_target_t *target,
-                              clap_id action_id) const noexcept;
-      bool contextMenuCanPopup() const noexcept;
+                              clap_id action_id) const noexcept override;
+      bool contextMenuCanPopup() const noexcept override;
       bool contextMenuPopup(const clap_context_menu_target_t *target,
                             int32_t screen_index,
                             int32_t x,
-                            int32_t y) const noexcept;
+                            int32_t y) const noexcept override;
 
       ///////////////////////////
       // clap_host_preset_load //
       ///////////////////////////
-      bool canUsePresetLoad() const noexcept;
+      bool canUsePresetLoad() const noexcept override;
       void presetLoadOnError(uint32_t location_kind,
                              const char *location,
                              const char *load_key,
                              int32_t os_error,
-                             const char *msg) const noexcept;
+                             const char *msg) const noexcept override;
       void presetLoadLoaded(uint32_t location_kind,
                             const char *location,
-                            const char *load_key) const noexcept;
+                            const char *load_key) const noexcept override;
 
       //////////////////////////////////
       // clap_host_resource_directory //
       //////////////////////////////////
-      bool canUseResourceDirectory() const noexcept;
-      bool requestDirectory(bool isShared) const noexcept;
-      void releaseDirectory(bool isShared) const noexcept;
+      bool canUseResourceDirectory() const noexcept override;
+      bool requestDirectory(bool isShared) const noexcept override;
+      void releaseDirectory(bool isShared) const noexcept override;
 
    protected:
       void ensureMainThread(const char *method) const noexcept;

--- a/include/clap/helpers/plugin-proxy.hh
+++ b/include/clap/helpers/plugin-proxy.hh
@@ -7,8 +7,160 @@
 #include "host.hh"
 
 namespace clap { namespace helpers {
+   // clap_plugin_audio_ports
    template <MisbehaviourHandler h, CheckingLevel l>
-   class PluginProxy {
+   class PluginAudioPortsProxy {
+   public:
+      virtual bool canUseAudioPorts() const noexcept = 0;
+      virtual uint32_t audioPortsCount(bool isInput) const noexcept = 0;
+      virtual bool
+      audioPortsGet(uint32_t index, bool isInput, clap_audio_port_info_t *info) const noexcept = 0;
+   };
+
+   // clap_plugin_gui
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginGuiProxy {
+   public:
+      virtual bool canUseGui() const noexcept = 0;
+      virtual bool guiIsApiSupported(const char *api, bool isFloating) const noexcept = 0;
+      virtual bool guiGetPreferredApi(const char **api, bool *isFloating) const noexcept = 0;
+      virtual bool guiCreate(const char *api, bool isFloating) const noexcept = 0;
+      virtual void guiDestroy() const noexcept = 0;
+      virtual bool guiSetScale(double scale) const noexcept = 0;
+      virtual bool guiGetSize(uint32_t *width, uint32_t *height) const noexcept = 0;
+      virtual bool guiCanResize() const noexcept = 0;
+      virtual bool guiGetResizeHints(clap_gui_resize_hints_t *hints) const noexcept = 0;
+      virtual bool guiAdjustSize(uint32_t *width, uint32_t *height) const noexcept = 0;
+      virtual bool guiSetSize(uint32_t width, uint32_t height) const noexcept = 0;
+      virtual bool guiSetParent(const clap_window_t *window) const noexcept = 0;
+      virtual bool guiSetTransient(const clap_window_t *window) const noexcept = 0;
+      virtual void guiSuggestTitle(const char *title) const noexcept = 0;
+      virtual bool guiShow() const noexcept = 0;
+      virtual bool guiHide() const noexcept = 0;
+   };
+
+   // clap_plugin_latency
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginLatencyProxy {
+   public:
+      virtual bool canUseLatency() const noexcept = 0;
+      virtual uint32_t latencyGet() const noexcept = 0;
+   };
+
+   // clap_plugin_note_ports
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginNotePortsProxy {
+   public:
+      virtual bool canUseNotePorts() const noexcept = 0;
+      virtual uint32_t notePortsCount(bool is_input) const noexcept = 0;
+      virtual bool
+      notePortsGet(uint32_t index, bool is_input, clap_note_port_info_t *info) const noexcept = 0;
+   };
+
+   // clap_plugin_params
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginParamsProxy {
+   public:
+      virtual bool canUseParams() const noexcept = 0;
+      virtual uint32_t paramsCount() const noexcept = 0;
+      virtual bool paramsGetInfo(uint32_t paramIndex,
+                                 clap_param_info_t *paramInfo) const noexcept = 0;
+      virtual bool paramsGetValue(clap_id paramId, double *outValue) const noexcept = 0;
+      virtual bool paramsValueToText(clap_id paramId,
+                                     double value,
+                                     char *outBuffer,
+                                     uint32_t outBufferCapacity) const noexcept = 0;
+      virtual bool paramsTextToValue(clap_id paramId,
+                                     const char *paramValueText,
+                                     double *outValue) const noexcept = 0;
+      virtual void paramsFlush(const clap_input_events_t *in,
+                               const clap_output_events_t *out) const noexcept = 0;
+   };
+
+   // clap_plugin_posix_fd_support
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginPosixFdSupportProxy {
+   public:
+      virtual bool canUsePosixFdSupport() const noexcept = 0;
+      virtual void posixFdSupportOnFd(int fd, clap_posix_fd_flags_t flags) const noexcept = 0;
+   };
+
+   // clap_plugin_preset_load
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginPresetLoadProxy {
+   public:
+      virtual bool canUsePresetLoad() const noexcept = 0;
+      virtual bool presetLoadFromLocation(uint32_t locationKind,
+                                          const char *location,
+                                          const char *loadKey) const noexcept = 0;
+   };
+
+   // clap_plugin_remote_controls
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginRemoteControlsProxy {
+   public:
+      virtual bool canUseRemoteControls() const noexcept = 0;
+      virtual uint32_t remoteControlsCount() const noexcept = 0;
+      virtual bool remoteControlsGet(uint32_t pageIndex,
+                                     clap_remote_controls_page_t *page) const noexcept = 0;
+   };
+
+   // clap_plugin_render
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginRenderProxy {
+   public:
+      virtual bool canUseRender() const noexcept = 0;
+      virtual bool renderHasHardRealtimeRequirement() const noexcept = 0;
+      virtual bool renderSet(clap_plugin_render_mode mode) const noexcept = 0;
+   };
+
+   // clap_plugin_state
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginStateProxy {
+   public:
+      virtual bool canUseState() const noexcept = 0;
+      virtual bool stateSave(const clap_ostream_t *stream) const noexcept = 0;
+      virtual bool stateLoad(const clap_istream_t *stream) const noexcept = 0;
+   };
+
+   // clap_plugin_tail
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginTailProxy {
+   public:
+      virtual bool canUseTail() const noexcept = 0;
+      virtual uint32_t tailGet() const noexcept = 0;
+   };
+
+   // clap_plugin_thread_pool
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginThreadPoolProxy {
+   public:
+      virtual bool canUseThreadPool() const noexcept = 0;
+      virtual void threadPoolExec(uint32_t taskIndex) const noexcept = 0;
+   };
+
+   // clap_plugin_timer_support
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginTimerSupportProxy {
+   public:
+      virtual bool canUseTimerSupport() const noexcept = 0;
+      virtual void timerSupportOnTimer(clap_id timerId) const noexcept = 0;
+   };
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginProxy : public PluginAudioPortsProxy<h, l>,
+                       public PluginGuiProxy<h, l>,
+                       public PluginLatencyProxy<h, l>,
+                       public PluginNotePortsProxy<h, l>,
+                       public PluginParamsProxy<h, l>,
+                       public PluginPosixFdSupportProxy<h, l>,
+                       public PluginPresetLoadProxy<h, l>,
+                       public PluginRemoteControlsProxy<h, l>,
+                       public PluginRenderProxy<h, l>,
+                       public PluginStateProxy<h, l>,
+                       public PluginTailProxy<h, l>,
+                       public PluginThreadPoolProxy<h, l>,
+                       public PluginTimerSupportProxy<h, l> {
    public:
       PluginProxy(const clap_plugin& plugin, const Host<h, l>& host) : _plugin{plugin}, _host{host} {}
 
@@ -31,114 +183,117 @@ namespace clap { namespace helpers {
       /////////////////////////////
       // clap_plugin_audio_ports //
       /////////////////////////////
-      bool canUseAudioPorts() const noexcept;
-      uint32_t audioPortsCount(bool isInput) const noexcept;
-      bool audioPortsGet(uint32_t index, bool isInput, clap_audio_port_info_t *info) const noexcept;
+      bool canUseAudioPorts() const noexcept override;
+      uint32_t audioPortsCount(bool isInput) const noexcept override;
+      bool audioPortsGet(uint32_t index,
+                         bool isInput,
+                         clap_audio_port_info_t *info) const noexcept override;
 
       /////////////////////
       // clap_plugin_gui //
       /////////////////////
-      bool canUseGui() const noexcept;
-      bool guiIsApiSupported(const char *api, bool isFloating) const noexcept;
-      bool guiGetPreferredApi(const char **api, bool *isFloating) const noexcept;
-      bool guiCreate(const char *api, bool isFloating) const noexcept;
-      void guiDestroy() const noexcept;
-      bool guiSetScale(double scale) const noexcept;
-      bool guiGetSize(uint32_t *width, uint32_t *height) const noexcept;
-      bool guiCanResize() const noexcept;
-      bool guiGetResizeHints(clap_gui_resize_hints_t *hints) const noexcept;
-      bool guiAdjustSize(uint32_t *width, uint32_t *height) const noexcept;
-      bool guiSetSize(uint32_t width, uint32_t height) const noexcept;
-      bool guiSetParent(const clap_window_t *window) const noexcept;
-      bool guiSetTransient(const clap_window_t *window) const noexcept;
-      void guiSuggestTitle(const char *title) const noexcept;
-      bool guiShow() const noexcept;
-      bool guiHide() const noexcept;
+      bool canUseGui() const noexcept override;
+      bool guiIsApiSupported(const char *api, bool isFloating) const noexcept override;
+      bool guiGetPreferredApi(const char **api, bool *isFloating) const noexcept override;
+      bool guiCreate(const char *api, bool isFloating) const noexcept override;
+      void guiDestroy() const noexcept override;
+      bool guiSetScale(double scale) const noexcept override;
+      bool guiGetSize(uint32_t *width, uint32_t *height) const noexcept override;
+      bool guiCanResize() const noexcept override;
+      bool guiGetResizeHints(clap_gui_resize_hints_t *hints) const noexcept override;
+      bool guiAdjustSize(uint32_t *width, uint32_t *height) const noexcept override;
+      bool guiSetSize(uint32_t width, uint32_t height) const noexcept override;
+      bool guiSetParent(const clap_window_t *window) const noexcept override;
+      bool guiSetTransient(const clap_window_t *window) const noexcept override;
+      void guiSuggestTitle(const char *title) const noexcept override;
+      bool guiShow() const noexcept override;
+      bool guiHide() const noexcept override;
 
       /////////////////////////
       // clap_plugin_latency //
       /////////////////////////
-      bool canUseLatency() const noexcept;
-      uint32_t latencyGet() const noexcept;
+      bool canUseLatency() const noexcept override;
+      uint32_t latencyGet() const noexcept override;
 
       ////////////////////////////
       // clap_plugin_note_ports //
       ////////////////////////////
-      bool canUseNotePorts() const noexcept;
-      uint32_t notePortsCount(bool is_input) const noexcept;
-      bool notePortsGet(uint32_t               index,
-                        bool                   is_input,
-                        clap_note_port_info_t *info) const noexcept;
+      bool canUseNotePorts() const noexcept override;
+      uint32_t notePortsCount(bool is_input) const noexcept override;
+      bool notePortsGet(uint32_t index,
+                        bool is_input,
+                        clap_note_port_info_t *info) const noexcept override;
 
       ////////////////////////
       // clap_plugin_params //
       ////////////////////////
-      bool canUseParams() const noexcept;
-      uint32_t paramsCount() const noexcept;
-      bool paramsGetInfo(uint32_t paramIndex, clap_param_info_t *paramInfo) const noexcept;
-      bool paramsGetValue(clap_id paramId, double *outValue) const noexcept;
+      bool canUseParams() const noexcept override;
+      uint32_t paramsCount() const noexcept override;
+      bool paramsGetInfo(uint32_t paramIndex, clap_param_info_t *paramInfo) const noexcept override;
+      bool paramsGetValue(clap_id paramId, double *outValue) const noexcept override;
       bool paramsValueToText(clap_id paramId,
                              double value,
                              char *outBuffer,
-                             uint32_t outBufferCapacity) const noexcept;
+                             uint32_t outBufferCapacity) const noexcept override;
       bool paramsTextToValue(clap_id paramId,
                              const char *paramValueText,
-                             double *outValue) const noexcept;
-      void paramsFlush(const clap_input_events_t *in, const clap_output_events_t *out) const noexcept;
+                             double *outValue) const noexcept override;
+      void paramsFlush(const clap_input_events_t *in,
+                       const clap_output_events_t *out) const noexcept override;
 
       //////////////////////////////////
       // clap_plugin_posix_fd_support //
       //////////////////////////////////
-      bool canUsePosixFdSupport() const noexcept;
-      void posixFdSupportOnFd(int fd, clap_posix_fd_flags_t flags) const noexcept;
+      bool canUsePosixFdSupport() const noexcept override;
+      void posixFdSupportOnFd(int fd, clap_posix_fd_flags_t flags) const noexcept override;
 
       /////////////////////////////
       // clap_plugin_preset_load //
       /////////////////////////////
-      bool canUsePresetLoad() const noexcept;
+      bool canUsePresetLoad() const noexcept override;
       bool presetLoadFromLocation(uint32_t locationKind,
                                   const char *location,
-                                  const char *loadKey)  const noexcept;
+                                  const char *loadKey) const noexcept override;
 
       /////////////////////////////////
       // clap_plugin_remote_controls //
       /////////////////////////////////
-      bool canUseRemoteControls() const noexcept;
-      uint32_t remoteControlsCount() const noexcept;
-      bool remoteControlsGet(uint32_t                     pageIndex,
-                             clap_remote_controls_page_t *page) const noexcept;
+      bool canUseRemoteControls() const noexcept override;
+      uint32_t remoteControlsCount() const noexcept override;
+      bool remoteControlsGet(uint32_t pageIndex,
+                             clap_remote_controls_page_t *page) const noexcept override;
 
       ////////////////////////
       // clap_plugin_render //
       ////////////////////////
-      bool canUseRender() const noexcept;
-      bool renderHasHardRealtimeRequirement() const noexcept;
-      bool renderSet(clap_plugin_render_mode mode) const noexcept;
+      bool canUseRender() const noexcept override;
+      bool renderHasHardRealtimeRequirement() const noexcept override;
+      bool renderSet(clap_plugin_render_mode mode) const noexcept override;
 
       ///////////////////////
       // clap_plugin_state //
       ///////////////////////
-      bool canUseState() const noexcept;
-      bool stateSave(const clap_ostream_t *stream) const noexcept;
-      bool stateLoad(const clap_istream_t *stream) const noexcept;
+      bool canUseState() const noexcept override;
+      bool stateSave(const clap_ostream_t *stream) const noexcept override;
+      bool stateLoad(const clap_istream_t *stream) const noexcept override;
 
       //////////////////////
       // clap_plugin_tail //
       //////////////////////
-      bool canUseTail() const noexcept;
-      uint32_t tailGet() const noexcept;
+      bool canUseTail() const noexcept override;
+      uint32_t tailGet() const noexcept override;
 
       /////////////////////////////
       // clap_plugin_thread_pool //
       /////////////////////////////
-      bool canUseThreadPool() const noexcept;
-      void threadPoolExec(uint32_t taskIndex) const noexcept;
+      bool canUseThreadPool() const noexcept override;
+      void threadPoolExec(uint32_t taskIndex) const noexcept override;
 
       ///////////////////////////////
       // clap_plugin_timer_support //
       ///////////////////////////////
-      bool canUseTimerSupport() const noexcept;
-      void timerSupportOnTimer(clap_id timerId) const noexcept;
+      bool canUseTimerSupport() const noexcept override;
+      void timerSupportOnTimer(clap_id timerId) const noexcept override;
 
    protected:
       /////////////////////


### PR DESCRIPTION
I had to try out this idea. What do you think?

Basic idea: If someone does not want allow full access to all extensions and plugin methods in a certain context, this would allow to pass only the needed extension proxy interfaces.