### PR TITLE
PluginProxy: fix order of constructor initialization list

### DIFF
--- a/include/clap/helpers/plugin-proxy.hh
+++ b/include/clap/helpers/plugin-proxy.hh
@@ -10,7 +10,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    class PluginProxy {
    public:
-      PluginProxy(const clap_plugin& plugin, const Host<h, l>& host) : _plugin{plugin}, _host{host} {}
+      PluginProxy(const clap_plugin& plugin, const Host<h, l>& host) : _host{host}, _plugin{plugin} {}
 
       /////////////////
       // clap_plugin //


### PR DESCRIPTION
trying to get this PR to build in order to have some proof-of-concept for `clap::helpers::PluginProxy`: https://github.com/free-audio/clap-wrapper/pull/177

It seems that the initialization order matters here. Changing this should not be an issue. I guess besides me almost no one is using the host helpers.