### PR TITLE
Include <exception> to fix "std::terminate" errors

### DIFF
--- a/include/clap/helpers/host-proxy.hxx
+++ b/include/clap/helpers/host-proxy.hxx
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <exception>
 #include <iostream>
 #include <sstream>
 

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <cstring>
+#include <exception>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
Newer versions of libc++ removed the transitive include for `<exception>` (see https://reviews.llvm.org/D146097), which causes an error when compiling. This patch adds an explicit include for `<exception>` to resolve this issue.
