### PR TITLE
Add base implementation of configurable audio ports extension

### DIFF
--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -150,6 +150,22 @@ namespace clap { namespace helpers {
          return false;
       }
 
+      //--------------------------------------//
+      // clap_plugin_configurable_audio_ports //
+      //--------------------------------------//
+      virtual bool implementsConfigurableAudioPorts() const noexcept { return false; }
+      virtual bool configurableAudioPortsCanApplyConfiguration(const clap_audio_port_configuration_request *requests,
+                                                               uint32_t request_count) const noexcept {
+         return false;
+      }
+      virtual bool configurableAudioPortsApplyConfiguration(const clap_audio_port_configuration_request *requests,
+                                                            uint32_t request_count) noexcept {
+         return false;
+      }
+      void ensureClapAudioPortConfigurationRequestIsValid(
+         const clap_audio_port_configuration_request *requests,
+         uint32_t request_count);
+
       //--------------------//
       // clap_plugin_params //
       //--------------------//
@@ -315,6 +331,11 @@ namespace clap { namespace helpers {
       void ensureAudioThread(const char *method) const noexcept;
       void ensureParamThread(const char *method) const noexcept;
 
+      ////////////////////
+      // General Checks //
+      ////////////////////
+      void ensureIsInactive(const char *methodName) const noexcept;
+
       ///////////////
       // Utilities //
       ///////////////
@@ -426,6 +447,14 @@ namespace clap { namespace helpers {
                                                     uint32_t port_index,
                                                     bool is_active,
                                                     uint32_t sample_size) noexcept;
+
+      // clap_plugin_configurable_audio_ports
+      static bool clapConfigurableAudioPortsCanApplyConfiguration(const clap_plugin_t *plugin, 
+                                                                  const clap_audio_port_configuration_request *requests, 
+                                                                  uint32_t request_count) noexcept;
+      static bool clapConfigurableAudioPortsApplyActivation(const clap_plugin_t *plugin, 
+                                                            const clap_audio_port_configuration_request *requests, 
+                                                            uint32_t request_count) noexcept;
 
       // clap_plugin_params
       static uint32_t clapParamsCount(const clap_plugin *plugin) noexcept;
@@ -552,6 +581,7 @@ namespace clap { namespace helpers {
       static const clap_plugin_audio_ports _pluginAudioPorts;
       static const clap_plugin_audio_ports_config _pluginAudioPortsConfig;
       static const clap_plugin_audio_ports_activation _pluginAudioPortsActivation;
+      static const clap_plugin_configurable_audio_ports _pluginConfigurableAudioPorts;
       static const clap_plugin_gui _pluginGui;
       static const clap_plugin_latency _pluginLatency;
       static const clap_plugin_note_name _pluginNoteName;

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -332,6 +332,7 @@ namespace clap { namespace helpers {
       // General Checks //
       ////////////////////
       void ensureIsInactive(const char *methodName) const noexcept;
+      void ensureIsActive(const char *methodName) const noexcept;
 
       ///////////////
       // Utilities //

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -162,9 +162,6 @@ namespace clap { namespace helpers {
                                                             uint32_t request_count) noexcept {
          return false;
       }
-      void ensureClapAudioPortConfigurationRequestIsValid(
-         const clap_audio_port_configuration_request *requests,
-         uint32_t request_count);
 
       //--------------------//
       // clap_plugin_params //

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -449,9 +449,9 @@ namespace clap { namespace helpers {
       static bool clapConfigurableAudioPortsCanApplyConfiguration(const clap_plugin_t *plugin, 
                                                                   const clap_audio_port_configuration_request *requests, 
                                                                   uint32_t request_count) noexcept;
-      static bool clapConfigurableAudioPortsApplyActivation(const clap_plugin_t *plugin, 
-                                                            const clap_audio_port_configuration_request *requests, 
-                                                            uint32_t request_count) noexcept;
+      static bool clapConfigurableAudioPortsApplyConfiguration(const clap_plugin_t *plugin, 
+                                                               const clap_audio_port_configuration_request *requests, 
+                                                               uint32_t request_count) noexcept;
 
       // clap_plugin_params
       static uint32_t clapParamsCount(const clap_plugin *plugin) noexcept;

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -64,7 +64,7 @@ namespace clap { namespace helpers {
    template <MisbehaviourHandler h, CheckingLevel l>
    const clap_plugin_configurable_audio_ports Plugin<h, l>::_pluginConfigurableAudioPorts = {
       clapConfigurableAudioPortsCanApplyConfiguration,
-      clapConfigurableAudioPortsApplyActivation,
+      clapConfigurableAudioPortsApplyConfiguration,
    };
 
 
@@ -818,7 +818,7 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   bool Plugin<h, l>::clapConfigurableAudioPortsApplyActivation(
+   bool Plugin<h, l>::clapConfigurableAudioPortsApplyConfiguration(
       const clap_plugin_t *plugin,
       const clap_audio_port_configuration_request *requests,
       uint32_t request_count) noexcept {

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -813,7 +813,6 @@ namespace clap { namespace helpers {
       auto methodName = "clap_plugin_configurable_audio_ports.can_apply_configuration";
       self.ensureMainThread(methodName);
       self.ensureIsInactive(methodName);
-      self.ensureClapAudioPortConfigurationRequestIsValid(requests, request_count);
 
       return self.configurableAudioPortsCanApplyConfiguration(requests, request_count);
    }
@@ -827,8 +826,6 @@ namespace clap { namespace helpers {
       auto methodName = "clap_plugin_configurable_audio_ports.apply_configuration";
       self.ensureMainThread(methodName);
       self.ensureIsInactive(methodName);
-      self.ensureClapAudioPortConfigurationRequestIsValid(requests, request_count);
-
       if (l >= CheckingLevel::Minimal &&
           !self.configurableAudioPortsCanApplyConfiguration(requests, request_count)) {
          self.hostMisbehaving(
@@ -840,26 +837,8 @@ namespace clap { namespace helpers {
       return self.configurableAudioPortsApplyConfiguration(requests, request_count);
    }
 
-   template <MisbehaviourHandler h, CheckingLevel l>
-   void Plugin<h, l>::ensureClapAudioPortConfigurationRequestIsValid(
-      const clap_audio_port_configuration_request *requests,
-      uint32_t request_count) {
-      if (l == CheckingLevel::None)
-         return;
 
-      for (int i = 0; i < request_count; ++i) {
-         if (!requests[i].port_type)
-            continue;
 
-         if (strcmp(requests[i].port_type, CLAP_PORT_MONO) == 0 && requests[i].channel_count != 1) {
-            hostMisbehaving("Host requested a mono port type with a channel count other than one.");
-         } else if (strcmp(requests[i].port_type, CLAP_PORT_STEREO) == 0 && requests[i].channel_count != 2) {
-            hostMisbehaving("Host requested a stereo port type with a channel count other than two.");
-         } else if (strcmp(requests[i].port_type, CLAP_PORT_SURROUND) == 0 && requests[i].channel_count < 3) {
-            hostMisbehaving("Host requested a surround port type with insufficient channel count.");
-         } else if (strcmp(requests[i].port_type, CLAP_PORT_AMBISONIC) == 0 && requests[i].channel_count < 4) {
-            hostMisbehaving("Host requested an ambisonic port type with insufficient channel count.");
-         }
       }
    }
 

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -1860,6 +1860,19 @@ namespace clap { namespace helpers {
       hostMisbehaving(msg.str());
    }
 
+   template <MisbehaviourHandler h, CheckingLevel l>
+   void Plugin<h, l>::ensureIsActive(const char *methodName) const noexcept {
+      if (l == CheckingLevel::None)
+         return;
+
+      if (isActive())
+         return;
+
+      std::ostringstream msg;
+      msg << "it is illegal to call " << methodName << "() while the plugin is not active!";
+      hostMisbehaving(msg.str());
+   }
+
    ///////////////
    // Utilities //
    ///////////////

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -826,20 +826,24 @@ namespace clap { namespace helpers {
       auto methodName = "clap_plugin_configurable_audio_ports.apply_configuration";
       self.ensureMainThread(methodName);
       self.ensureIsInactive(methodName);
-      if (l >= CheckingLevel::Minimal &&
-          !self.configurableAudioPortsCanApplyConfiguration(requests, request_count)) {
-         self.hostMisbehaving(
-            "Host requested a configuration that the plugin did not accept. Check with "
-            "clap_plugin_configurable_audio_ports.can_apply_configuration before applying a "
-            "configuration!");
+
+      bool canApplyConfiguration;
+      if (l >= CheckingLevel::Minimal) {
+         canApplyConfiguration =
+            self.configurableAudioPortsCanApplyConfiguration(requests, request_count);
       }
 
-      return self.configurableAudioPortsApplyConfiguration(requests, request_count);
-   }
+      bool applyConfigurationSuccess =
+         self.configurableAudioPortsApplyConfiguration(requests, request_count);
 
-
-
+      if (l >= CheckingLevel::Minimal && canApplyConfiguration != applyConfigurationSuccess) {
+         self._host.pluginMisbehaving(
+            "Plugin's functions clap_plugin_configurable_audio_ports.can_apply_configuration and "
+            "clap_plugin_configurable_audio_ports.apply_configuration returned different values "
+            "for the same configuration.");
       }
+
+      return applyConfigurationSuccess;
    }
 
    //--------------------//


### PR DESCRIPTION
This PR adds the configurable audio ports extension to the clap-helpers so that consumers of the clap-helpers can implement it into their plugins. It also adds some minimal level checks to the base implementation. 