### PR TITLE
Correct  Plugin::clapExtension

### DIFF
--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -484,7 +484,7 @@ namespace clap { namespace helpers {
          return &_pluginAudioPorts;
       if ((!strcmp(id, CLAP_EXT_AUDIO_PORTS_ACTIVATION) ||
            !strcmp(id, CLAP_EXT_AUDIO_PORTS_ACTIVATION_COMPAT)) &&
-          self.implementsAudioPorts())
+          self.implementsAudioPortsActivation())
          return &_pluginAudioPortsActivation;
       if (!strcmp(id, CLAP_EXT_AUDIO_PORTS_CONFIG) && self.implementsAudioPortsConfig())
          return &_pluginAudioPortsConfig;


### PR DESCRIPTION
Hei.
I think it was mistake. Here is correct version.