### PR TITLE
Remove unnecessary includes

### DIFF
--- a/tests/create-an-actual-host.cc
+++ b/tests/create-an-actual-host.cc
@@ -2,9 +2,7 @@
  * Actually use host.hh / host.hxx to create a host. Assert that it is constructable
  */
 
-#include "clap/helpers/host.hh"
 #include "clap/helpers/host.hxx"
-#include "clap/helpers/plugin-proxy.hh"
 #include "clap/helpers/plugin-proxy.hxx"
 
 #include <type_traits>

--- a/tests/create-an-actual-plugin.cc
+++ b/tests/create-an-actual-plugin.cc
@@ -2,7 +2,6 @@
  * Actually use plugin.hh / plugin.hxx to create a plugin. Assert that it is constructable
  */
 
-#include "clap/helpers/plugin.hh"
 #include "clap/helpers/plugin.hxx"
 
 #include <type_traits>

--- a/tests/host.cc
+++ b/tests/host.cc
@@ -1,5 +1,4 @@
 #include <clap/helpers/plugin-proxy.hxx>
-#include <clap/helpers/host.hh>
 #include <clap/helpers/host.hxx>
 
 #include <catch2/catch_all.hpp>

--- a/tests/plugin.cc
+++ b/tests/plugin.cc
@@ -1,8 +1,6 @@
 #include <clap/helpers/host-proxy.hxx>
 #include <clap/helpers/param-queue.hh>
-#include <clap/helpers/plugin.hh>
 #include <clap/helpers/plugin.hxx>
-#include <clap/helpers/reducing-param-queue.hh>
 #include <clap/helpers/reducing-param-queue.hxx>
 
 #include <catch2/catch_all.hpp>


### PR DESCRIPTION
just a nitpick: the `.hh` headers are already included via the `.hxx` headers