### PR TITLE
PluginEntry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,12 +61,14 @@ if (${CLAP_HELPERS_BUILD_TESTS})
             tests/hex-encoder.cc
             tests/host.cc
             tests/plugin.cc
+            tests/plugin-entry.cc
             tests/param-queue-tests.cc
             tests/event-list-tests.cc
             tests/main.cc
             tests/preset-discovery-indexer.cc
             tests/preset-discovery-provider.cc
             tests/preset-discovery-metadata-receiver.cc
+            tests/use-plugin-entry.cc
     )
     set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD ${CLAP_HELPERS_TESTS_CXX_STANDARD})
     set_target_properties(${PROJECT_NAME}-tests PROPERTIES CXX_STANDARD ${CLAP_HELPERS_TESTS_CXX_STANDARD})

--- a/include/clap/helpers/plugin-entry.hh
+++ b/include/clap/helpers/plugin-entry.hh
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <clap/all.h>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <type_traits>
+
+#include "checking-level.hh"
+#include "misbehaviour-handler.hh"
+
+namespace clap { namespace helpers {
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   class PluginEntry {
+   public:
+      // not copyable, not moveable
+      PluginEntry(const PluginEntry &) = delete;
+      PluginEntry(PluginEntry &&) = delete;
+      PluginEntry &operator=(const PluginEntry &) = delete;
+      PluginEntry &operator=(PluginEntry &&) = delete;
+
+      // function that produces the clap_plugin_entry to be exported
+      // template T needs to be derived from PluginEntry and default-constructible
+      template <typename T,
+                typename = typename std::enable_if<std::is_base_of<PluginEntry, T>::value &&
+                                                   std::is_default_constructible<T>::value>::type>
+      static const clap_plugin_entry clapPluginEntry() noexcept;
+
+   protected:
+      PluginEntry() = default;
+      virtual ~PluginEntry() = default;
+
+      /////////////////////////
+      // Methods to override //
+      /////////////////////////
+
+      // clap_plugin_entry
+      virtual bool init(const char *plugin_path) noexcept { return true; }
+      virtual void deinit() noexcept {}
+      virtual const void *getFactory(const char *factoryId) const noexcept { return nullptr; };
+      virtual bool enableDraftFactories() const noexcept { return false; }
+
+      // clap_plugin_factory
+      virtual bool implementsPluginFactory() const noexcept { return false; }
+      virtual uint32_t pluginFactoryGetPluginCount() const noexcept { return 0; }
+      virtual const clap_plugin_descriptor_t *
+      pluginFactoryGetPluginDescriptor(uint32_t index) const noexcept {
+         return nullptr;
+      }
+      virtual const clap_plugin_t *pluginFactoryCreatePlugin(const clap_host_t &host,
+                                                             const char *plugin_id) const noexcept {
+         return nullptr;
+      }
+      // This method is meant for implementing contract checking, it isn't part of CLAP.
+      // The default implementation will be slow, so consider overriding it with a faster one.
+      // Returns -1 if the plugin isn't found.
+      virtual int32_t getPluginIndexForPluginId(const char *pluginId) const noexcept;
+      virtual bool isValidPluginId(const char *pluginId) const noexcept;
+      virtual const clap_plugin_descriptor *
+      getPluginDescriptorForPluginId(const char *pluginId) const noexcept;
+
+   private:
+      // custom deleter so the virtual destructor does not have to be public
+      static void deletePluginEntry(PluginEntry<h, l> *) noexcept;
+      using InstancePtr = std::unique_ptr<PluginEntry<h, l>, void (*)(PluginEntry<h, l> *)>;
+      static InstancePtr _instance;
+
+      /////////////
+      // Utility //
+      /////////////
+
+      static void hostMisbehaving(const char *msg) noexcept;
+      static void hostMisbehaving(const std::string &msg) noexcept { hostMisbehaving(msg.c_str()); }
+      static bool ensureInitialized(const char *method) noexcept;
+      template <typename T>
+      static bool
+      ensureFactory(const T *factory, const T &staticFactory, const char *method) noexcept;
+
+      /////////////////////
+      // CLAP Interfaces //
+      /////////////////////
+
+      // clap_plugin_entry
+      template <typename T>
+      static bool clapInit(const char *plugin_path) noexcept;
+      static void clapDeinit() noexcept;
+      static const void *clapGetFactory(const char *factory_id) noexcept;
+      static std::mutex _initLock;
+      static int _initCounter;
+
+      // clap_plugin_factory
+      static uint32_t clapPluginFactoryGetPluginCount(const clap_plugin_factory *factory) noexcept;
+      static const clap_plugin_descriptor *
+      clapPluginFactoryGetPluginDescriptor(const clap_plugin_factory *factory,
+                                           uint32_t index) noexcept;
+      static const clap_plugin_t *clapPluginFactoryCreatePlugin(const clap_plugin_factory *factory,
+                                                                const clap_host *host,
+                                                                const char *plugin_id);
+
+      // interfaces
+      static const clap_plugin_factory _pluginEntryPluginFactory;
+   };
+}} // namespace clap::helpers

--- a/include/clap/helpers/plugin-entry.hh
+++ b/include/clap/helpers/plugin-entry.hh
@@ -68,8 +68,10 @@ namespace clap { namespace helpers {
 
    private:
       // custom deleter so the virtual destructor does not have to be public
-      static void deletePluginEntry(PluginEntry<h, l> *) noexcept;
-      using InstancePtr = std::unique_ptr<PluginEntry<h, l>, void (*)(PluginEntry<h, l> *)>;
+      struct Deleter {
+            void operator()(PluginEntry<h, l> *pluginEntry) const noexcept;
+      };
+      using InstancePtr = std::unique_ptr<PluginEntry<h, l>, Deleter>;
       static InstancePtr _instance;
 
       /////////////

--- a/include/clap/helpers/plugin-entry.hh
+++ b/include/clap/helpers/plugin-entry.hh
@@ -41,6 +41,11 @@ namespace clap { namespace helpers {
       virtual void deinit() noexcept {}
       virtual const void *getFactory(const char *factoryId) const noexcept { return nullptr; };
       virtual bool enableDraftFactories() const noexcept { return false; }
+      // needed for adding custom factories to a class derived from PluginEntry
+      template <typename T,
+                typename = typename std::enable_if<std::is_base_of<PluginEntry, T>::value &&
+                                                   std::is_default_constructible<T>::value>::type>
+      static const T &getInstance() noexcept;
 
       // clap_plugin_factory
       virtual bool implementsPluginFactory() const noexcept { return false; }

--- a/include/clap/helpers/plugin-entry.hxx
+++ b/include/clap/helpers/plugin-entry.hxx
@@ -1,0 +1,248 @@
+#include "plugin-entry.hh"
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+
+namespace clap { namespace helpers {
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   const clap_plugin_factory PluginEntry<h, l>::_pluginEntryPluginFactory = {
+      clapPluginFactoryGetPluginCount,
+      clapPluginFactoryGetPluginDescriptor,
+      clapPluginFactoryCreatePlugin,
+   };
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   template <typename T, typename ValidImpl>
+   const clap_plugin_entry PluginEntry<h, l>::clapPluginEntry() noexcept {
+      return clap_plugin_entry{
+         CLAP_VERSION,
+         clapInit<T>,
+         clapDeinit,
+         clapGetFactory,
+      };
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   int32_t PluginEntry<h, l>::getPluginIndexForPluginId(const char *pluginId) const noexcept {
+      const auto count = pluginFactoryGetPluginCount();
+      for (uint32_t i = 0; i < count; ++i) {
+         auto desc = pluginFactoryGetPluginDescriptor(i);
+         if (!std::strcmp(desc->id, pluginId))
+            return static_cast<int32_t>(i);
+      }
+      return -1;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool PluginEntry<h, l>::isValidPluginId(const char *pluginId) const noexcept {
+      return getPluginIndexForPluginId(pluginId) != -1;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   const clap_plugin_descriptor *
+   PluginEntry<h, l>::getPluginDescriptorForPluginId(const char *pluginId) const noexcept {
+      const auto count = pluginFactoryGetPluginCount();
+      for (uint32_t i = 0; i < count; ++i) {
+         auto desc = pluginFactoryGetPluginDescriptor(i);
+         if (!std::strcmp(desc->id, pluginId))
+            return desc;
+      }
+      return nullptr;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   void PluginEntry<h, l>::deletePluginEntry(PluginEntry<h, l> *pluginEntry) noexcept {
+      delete pluginEntry;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   typename PluginEntry<h, l>::InstancePtr PluginEntry<h, l>::_instance{nullptr, deletePluginEntry};
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   void PluginEntry<h, l>::hostMisbehaving(const char *msg) noexcept {
+      std::cerr << msg << std::endl;
+      if (h == MisbehaviourHandler::Terminate)
+         std::terminate();
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   bool PluginEntry<h, l>::ensureInitialized(const char *method) noexcept {
+      if (l >= CheckingLevel::Minimal && !_instance) {
+         std::ostringstream msg;
+         msg << "Host called the method " << method
+             << " before plugin_entry.init or after plugin_entry.deinit";
+         hostMisbehaving(msg.str());
+         return false;
+      }
+      return true;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   template <typename T>
+   bool PluginEntry<h, l>::ensureFactory(const T *factory,
+                                         const T &staticFactory,
+                                         const char *method) noexcept {
+      if (!ensureInitialized(method))
+         return false;
+      if (l >= CheckingLevel::Minimal && factory != &staticFactory) {
+         std::ostringstream msg;
+         msg << "Host called the method " << method << " with an invalid factory pointer";
+         hostMisbehaving(msg.str());
+         return false;
+      }
+      return true;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   template <typename T>
+   bool PluginEntry<h, l>::clapInit(const char *plugin_path) noexcept {
+      if (l >= CheckingLevel::Minimal) {
+         const auto method = "plugin_entry.init";
+         if (!plugin_path || !plugin_path[0]) {
+            std::ostringstream msg;
+            msg << "Host called the method " << method << " with null or empty plugin_path";
+            hostMisbehaving(msg.str());
+            return false;
+         }
+      }
+      std::lock_guard<std::mutex> guard(_initLock);
+      const auto count = ++_initCounter;
+      if (count > 1)
+         return true;
+      assert(!_instance && "the _initCounter mechanism should protect us from initializing twice");
+      auto impl = new T();
+      if (!impl->init(plugin_path)) {
+         _initCounter = 0;
+         return false;
+      }
+      _instance = InstancePtr(static_cast<PluginEntry *>(impl), deletePluginEntry);
+      return true;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   void PluginEntry<h, l>::clapDeinit() noexcept {
+      std::lock_guard<std::mutex> guard(_initLock);
+      const auto count = --_initCounter;
+      if (count == 0) {
+         assert(_instance &&
+                "the _initCounter mechanism should protect us from deinitializing twice");
+         _instance->deinit();
+         _instance.reset();
+      }
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   std::mutex PluginEntry<h, l>::_initLock{};
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   int PluginEntry<h, l>::_initCounter{};
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   const void *PluginEntry<h, l>::clapGetFactory(const char *factory_id) noexcept {
+      if (!ensureInitialized("plugin_entry.get_factory"))
+         return nullptr;
+      auto &self = *_instance;
+      if (!std::strcmp(factory_id, CLAP_PLUGIN_FACTORY_ID) && self.implementsPluginFactory())
+         return &_pluginEntryPluginFactory;
+      if (self.enableDraftFactories()) {
+         // put draft factories here
+      }
+      return self.getFactory(factory_id);
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   uint32_t
+   PluginEntry<h, l>::clapPluginFactoryGetPluginCount(const clap_plugin_factory *factory) noexcept {
+      if (!ensureFactory(factory, _pluginEntryPluginFactory, "plugin_factory.get_plugin_count"))
+         return 0;
+      auto &self = *_instance;
+      return self.pluginFactoryGetPluginCount();
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   const clap_plugin_descriptor *
+   PluginEntry<h, l>::clapPluginFactoryGetPluginDescriptor(const clap_plugin_factory *factory,
+                                                           uint32_t index) noexcept {
+      const auto method = "plugin_factory.get_plugin_descriptor";
+      if (!ensureFactory(factory, _pluginEntryPluginFactory, method))
+         return nullptr;
+      auto &self = *_instance;
+      if (l >= CheckingLevel::Minimal) {
+         auto count = self.pluginFactoryGetPluginCount();
+         if (index >= count) {
+            std::ostringstream msg;
+            msg << "Host called " << method << " with an index out of bounds: " << index
+                << " >= " << count;
+            hostMisbehaving(msg.str());
+            return nullptr;
+         }
+      }
+      auto desc = self.pluginFactoryGetPluginDescriptor(index);
+      assert(desc && "pluginFactoryGetPluginDescriptor must not return nullptr");
+      assert(desc->id && desc->id[0] && desc->name && desc->name[0] &&
+             "for the clap_plugin_descriptor returned by pluginFactoryGetPluginDescriptor, all "
+             "mandatory fields must be set properly");
+      assert(desc->vendor && desc->url && desc->manual_url && desc->support_url && desc->version &&
+             desc->description && desc->features &&
+             "for the clap_plugin_descriptor returned by pluginFactoryGetPluginDescriptor, all "
+             "non-mandatory fields must be set non-zero (at least blank)");
+      return desc;
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
+   const clap_plugin_t *PluginEntry<h, l>::clapPluginFactoryCreatePlugin(
+      const struct clap_plugin_factory *factory, const clap_host *host, const char *plugin_id) {
+      const auto method = "plugin_factory.create_plugin";
+      if (!ensureFactory(factory, _pluginEntryPluginFactory, method))
+         return nullptr;
+      if (l >= CheckingLevel::Minimal) {
+         if (!host) {
+            std::ostringstream msg;
+            msg << "Host called " << method << " with a host nullptr";
+            hostMisbehaving(msg.str());
+            return nullptr;
+         }
+         if (!plugin_id) {
+            std::ostringstream msg;
+            msg << "Host called " << method << " with a plugin_id nullptr";
+            hostMisbehaving(msg.str());
+            return nullptr;
+         }
+         if (!clap_version_is_compatible(host->clap_version)) {
+            std::ostringstream msg;
+            msg << "Host called " << method << " with a host of an incompatible clap version";
+            hostMisbehaving(msg.str());
+            return nullptr;
+         }
+         if (!host->name || !host->version || !host->get_extension || !host->request_restart ||
+             !host->request_process || !host->request_callback) {
+            std::ostringstream msg;
+            msg << "Host called " << method << " with a host not completely implemented";
+            hostMisbehaving(msg.str());
+            return nullptr;
+         }
+      }
+      auto &self = *_instance;
+      if (l >= CheckingLevel::Maximal) {
+         if (!self.isValidPluginId(plugin_id)) {
+            std::ostringstream msg;
+            msg << "Host called " << method << " with an invalid plugin_id: " << plugin_id;
+            hostMisbehaving(msg.str());
+         }
+      }
+      auto plugin = self.pluginFactoryCreatePlugin(*host, plugin_id);
+      assert(plugin && "pluginFactoryCreatePlugin must not return nullptr");
+      assert(plugin->desc && plugin->init && plugin->destroy && plugin->activate &&
+             plugin->deactivate && plugin->start_processing && plugin->stop_processing &&
+             plugin->reset && plugin->process && plugin->get_extension && plugin->on_main_thread &&
+             "pluginFactoryCreatePlugin must return a completely implemented clap_plugin");
+      assert(plugin->desc == self.getPluginDescriptorForPluginId(plugin_id) &&
+             "for the clap_plugin returned by pluginFactoryCreatePlugin, plugin->desc must point "
+             "to the same plugin_descriptor as plugin_factory.get_plugin_descriptor would return");
+      return plugin;
+   }
+
+}} // namespace clap::helpers

--- a/include/clap/helpers/plugin-entry.hxx
+++ b/include/clap/helpers/plugin-entry.hxx
@@ -26,6 +26,14 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
+   template <typename T, typename ValidImpl>
+   const T &PluginEntry<h, l>::getInstance() noexcept {
+      assert(_instance &&
+             "make sure to call this only between plugin_entry.init and plugin_entry.deinit");
+      return *static_cast<const T *>(_instance.get());
+   }
+
+   template <MisbehaviourHandler h, CheckingLevel l>
    int32_t PluginEntry<h, l>::getPluginIndexForPluginId(const char *pluginId) const noexcept {
       const auto count = pluginFactoryGetPluginCount();
       for (uint32_t i = 0; i < count; ++i) {

--- a/include/clap/helpers/plugin-entry.hxx
+++ b/include/clap/helpers/plugin-entry.hxx
@@ -62,12 +62,12 @@ namespace clap { namespace helpers {
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   void PluginEntry<h, l>::deletePluginEntry(PluginEntry<h, l> *pluginEntry) noexcept {
+   void PluginEntry<h, l>::PluginEntry::Deleter::operator()(PluginEntry<h, l> *pluginEntry) const noexcept {
       delete pluginEntry;
    }
 
    template <MisbehaviourHandler h, CheckingLevel l>
-   typename PluginEntry<h, l>::InstancePtr PluginEntry<h, l>::_instance{nullptr, deletePluginEntry};
+   typename PluginEntry<h, l>::InstancePtr PluginEntry<h, l>::_instance{};
 
    template <MisbehaviourHandler h, CheckingLevel l>
    void PluginEntry<h, l>::hostMisbehaving(const char *msg) noexcept {
@@ -126,7 +126,7 @@ namespace clap { namespace helpers {
          _initCounter = 0;
          return false;
       }
-      _instance = InstancePtr(static_cast<PluginEntry *>(impl), deletePluginEntry);
+      _instance.reset(static_cast<PluginEntry *>(impl));
       return true;
    }
 

--- a/include/clap/helpers/plugin-proxy.hh
+++ b/include/clap/helpers/plugin-proxy.hh
@@ -146,6 +146,12 @@ namespace clap { namespace helpers {
       void locationSetLocation(const clap_plugin_location_element_t *path,
                                uint32_t num_elements) const noexcept;
 
+      ///////////////////////////////////
+      // clap_gain_adjustment_metering //
+      ///////////////////////////////////
+      bool canUseGainAdjustmentMetering() const noexcept;
+      double gainAdjustmentMeteringGet() const noexcept;
+
    protected:
       /////////////////////
       // Thread Checking //
@@ -173,6 +179,7 @@ namespace clap { namespace helpers {
       const clap_plugin_thread_pool *_pluginThreadPool = nullptr;
       const clap_plugin_timer_support *_pluginTimerSupport = nullptr;
       const clap_plugin_location *_pluginLocation = nullptr;
+      const clap_plugin_gain_adjustment_metering *_pluginGainAdjustmentMetering = nullptr;
 
       // state
       bool _isActive = false;

--- a/include/clap/helpers/plugin-proxy.hxx
+++ b/include/clap/helpers/plugin-proxy.hxx
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <cmath>
 #include <sstream>
 
 #include "plugin-proxy.hh"

--- a/include/clap/helpers/plugin.hh
+++ b/include/clap/helpers/plugin.hh
@@ -330,12 +330,20 @@ namespace clap { namespace helpers {
       virtual void locationSetLocation(const clap_plugin_location_element_t *path,
                                        uint32_t num_elements) noexcept {}
 
+      //--------------------------------------//
+      // clap_plugin_gain_adjustment_metering //
+      //--------------------------------------//
+      virtual bool implementsGainAdjustmentMetering() const noexcept { return false; }
+      virtual double gainAdjustmentMeteringGet() noexcept { return 0; }
+
       /////////////
       // Logging //
       /////////////
       void log(clap_log_severity severity, const char *msg) const noexcept;
       void hostMisbehaving(const char *msg) const noexcept;
       void hostMisbehaving(const std::string &msg) const noexcept { hostMisbehaving(msg.c_str()); }
+      void pluginMisbehaving(const char *msg) const noexcept;
+      void pluginMisbehaving(const std::string &msg) const noexcept { pluginMisbehaving(msg.c_str()); }
 
       // Receives a copy of all the logging messages sent to the host.
       // This is useful to have the messages in both the host's logs and the plugin's logs.
@@ -614,6 +622,9 @@ namespace clap { namespace helpers {
                                           const clap_plugin_location_element_t *path,
                                           uint32_t num_elements) noexcept;
 
+      // clap_plugin_gain_adjustment_metering
+      static double clapGainAdjustmentMeteringGet(const clap_plugin_t *plugin) noexcept;
+
       // interfaces
       static const clap_plugin_audio_ports _pluginAudioPorts;
       static const clap_plugin_audio_ports_config _pluginAudioPortsConfig;
@@ -641,6 +652,7 @@ namespace clap { namespace helpers {
       static const clap_plugin_undo_delta _pluginUndoDelta;
       static const clap_plugin_undo_context _pluginUndoContext;
       static const clap_plugin_location _pluginLocation;
+      static const clap_plugin_gain_adjustment_metering _pluginGainAdjustmentMetering;
 
       // state
       bool _wasInitialized = false;

--- a/include/clap/helpers/plugin.hxx
+++ b/include/clap/helpers/plugin.hxx
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <cmath>
 #include <cstring>
 #include <exception>
 #include <iostream>

--- a/tests/plugin-entry.cc
+++ b/tests/plugin-entry.cc
@@ -1,0 +1,23 @@
+#include "clap/helpers/plugin-entry.hxx"
+
+#include <catch2/catch_all.hpp>
+
+template class clap::helpers::PluginEntry<clap::helpers::MisbehaviourHandler::Terminate,
+                                          clap::helpers::CheckingLevel::Maximal>;
+template class clap::helpers::PluginEntry<clap::helpers::MisbehaviourHandler::Terminate,
+                                          clap::helpers::CheckingLevel::Minimal>;
+template class clap::helpers::PluginEntry<clap::helpers::MisbehaviourHandler::Terminate,
+                                          clap::helpers::CheckingLevel::None>;
+template class clap::helpers::PluginEntry<clap::helpers::MisbehaviourHandler::Ignore,
+                                          clap::helpers::CheckingLevel::Maximal>;
+
+CATCH_TEST_CASE("PluginEntry - Link") {
+   clap::helpers::PluginEntry<clap::helpers::MisbehaviourHandler::Terminate,
+                              clap::helpers::CheckingLevel::Maximal> *e0 = nullptr;
+   clap::helpers::PluginEntry<clap::helpers::MisbehaviourHandler::Terminate,
+                              clap::helpers::CheckingLevel::Minimal> *e1 = nullptr;
+   clap::helpers::PluginEntry<clap::helpers::MisbehaviourHandler::Terminate,
+                              clap::helpers::CheckingLevel::None> *e2 = nullptr;
+   clap::helpers::PluginEntry<clap::helpers::MisbehaviourHandler::Ignore,
+                              clap::helpers::CheckingLevel::Maximal> *e3 = nullptr;
+}

--- a/tests/use-plugin-entry.cc
+++ b/tests/use-plugin-entry.cc
@@ -1,0 +1,100 @@
+#include "clap/helpers/host.hxx"
+#include "clap/helpers/plugin-entry.hxx"
+#include "clap/helpers/plugin.hxx"
+
+#include <catch2/catch_all.hpp>
+
+namespace {
+   using test_entry = clap::helpers::PluginEntry<clap::helpers::MisbehaviourHandler::Terminate,
+                                                 clap::helpers::CheckingLevel::Maximal>;
+
+   struct test_entry_default_impl : public test_entry {};
+
+   CATCH_TEST_CASE("Use PluginEntry default implementation") {
+      auto clapPluginEntry = test_entry::clapPluginEntry<test_entry_default_impl>();
+      CATCH_CHECK(clapPluginEntry.init("test/plugin/path"));
+      CATCH_CHECK(!clapPluginEntry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+      clapPluginEntry.deinit();
+   }
+
+   struct test_entry_custom_impl : public test_entry {
+      static std::string _initPluginPath;
+      using plugin_glue = clap::helpers::Plugin<clap::helpers::MisbehaviourHandler::Ignore,
+                                                clap::helpers::CheckingLevel::Minimal>;
+      struct plugin : plugin_glue {
+         static const clap_plugin_descriptor *getDescription() {
+            static const char *features[] = {nullptr};
+            static clap_plugin_descriptor desc = {CLAP_VERSION,
+                                                  "org.free-audio.test-case.plugin",
+                                                  "Test Case Plugin",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  &features[0]};
+            return &desc;
+         }
+
+         plugin(const clap_host &host) : plugin_glue(getDescription(), &host) {}
+      };
+
+      bool implementsPluginFactory() const noexcept override { return true; }
+      uint32_t pluginFactoryGetPluginCount() const noexcept override { return 1; }
+      const clap_plugin_descriptor_t *
+      pluginFactoryGetPluginDescriptor(uint32_t) const noexcept override {
+         return plugin::getDescription();
+      }
+      const clap_plugin *pluginFactoryCreatePlugin(const clap_host_t &host,
+                                                   const char *) const noexcept override {
+         return (new plugin(host))->clapPlugin();
+      }
+
+      bool init(const char *pluginPath) noexcept override {
+         _initPluginPath = pluginPath;
+         return true;
+      }
+      void deinit() noexcept override { _initPluginPath.clear(); }
+   };
+   std::string test_entry_custom_impl::_initPluginPath{};
+
+   using test_host_glue = clap::helpers::Host<clap::helpers::MisbehaviourHandler::Ignore,
+                                              clap::helpers::CheckingLevel::Minimal>;
+   struct test_host : test_host_glue {
+      test_host() : test_host_glue{"Test Case Host", nullptr, nullptr, "1.0.0"} {}
+      bool threadCheckIsMainThread() const noexcept override { return true; };
+      bool threadCheckIsAudioThread() const noexcept override { return false; };
+      void requestRestart() noexcept override {};
+      void requestProcess() noexcept override {};
+      void requestCallback() noexcept override {};
+   };
+
+   CATCH_TEST_CASE("Use PluginEntry custom implementation") {
+      CATCH_CHECK(test_entry_custom_impl::_initPluginPath.empty());
+      const auto clapPluginEntry = test_entry::clapPluginEntry<test_entry_custom_impl>();
+
+      // clap_plugin_entry.init
+      const auto testPluginPath = "test/plugin/path";
+      CATCH_CHECK(clapPluginEntry.init(testPluginPath));
+      CATCH_CHECK(test_entry_custom_impl::_initPluginPath == testPluginPath);
+
+      // clap_plugin_factory
+      const auto factory = static_cast<const clap_plugin_factory *>(
+         clapPluginEntry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+      CATCH_REQUIRE(factory);
+      CATCH_CHECK(factory->get_plugin_count(factory) == 1);
+      CATCH_REQUIRE(factory->get_plugin_descriptor(factory, 0) ==
+                    test_entry_custom_impl::plugin::getDescription());
+      test_host testHost;
+      const auto plugin = factory->create_plugin(
+         factory, testHost.clapHost(), test_entry_custom_impl::plugin::getDescription()->id);
+      CATCH_REQUIRE(plugin);
+      CATCH_CHECK(plugin->desc == test_entry_custom_impl::plugin::getDescription());
+      plugin->destroy(plugin); // clean up after test
+
+      // clap_plugin_entry.deinit
+      clapPluginEntry.deinit();
+      CATCH_CHECK(test_entry_custom_impl::_initPluginPath.empty());
+   }
+} // namespace


### PR DESCRIPTION
first version for a + clap::helpers::PluginEntry`
- works for local plugin project (single-plugin clap, multi-plugin clap)
- has the thread safety checks built-in
- some basic test
- some points I would rather leave for later as they are more on the optimization side:
  - only plugin_factory supported for now but it should be easy to add the other factories in the future
  - `CLAP_HELPERS_UNLIKELY` might be nice for some of the checks
  - the `plugin_path` on `plugin_entry.init` could be checked better (whether it's actually a valid path, see TODO comment)
  - maybe add some test for a multi-plugin plugin factory later

resolves #74 (this is a more general approach and leaves the actual implementation more up to the user which i think is better)