### PR TITLE
Add some more cmake options for downloads etc

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -98,7 +98,7 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Configure project (next)
-        if: github.ref != 'refs/heads/next'
+        if: github.ref == 'refs/heads/next'
         run: |
           cmake -S . -B ./build ${{ matrix.cmakeargs }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_HELPERS_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_HELPERS_BUILD_TESTS=TRUE -DCLAP_HELPERS_DOWNLOAD_CLAP_BRANCH_IS_NEXT=TRUE
 

--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -97,9 +97,18 @@ jobs:
         if: ${{ matrix.install_ninja }}
         uses: seanmiddleditch/gha-setup-ninja@master
 
-      - name: Build project
+      - name: Configure project (next)
+        if: github.ref != 'refs/heads/next'
+        run: |
+          cmake -S . -B ./build ${{ matrix.cmakeargs }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_HELPERS_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_HELPERS_BUILD_TESTS=TRUE -DCLAP_HELPERS_DOWNLOAD_CLAP_BRANCH_IS_NEXT=TRUE
+
+      - name: Configure project (not next)
+        if: github.ref != 'refs/heads/next'
         run: |
           cmake -S . -B ./build ${{ matrix.cmakeargs }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_HELPERS_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_HELPERS_BUILD_TESTS=TRUE
+
+      - name: Build Project
+        run: |
           cmake --build ./build --config Debug --target clap-helpers-tests --parallel
 
       - name: Run Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(${PROJECT_NAME} INTERFACE include)
 
 if (NOT TARGET clap)
     if (${CLAP_HELPERS_DOWNLOAD_DEPENDENCIES})
-        if (${CLAP_HELPERS_DOWNLOQD_CLAP_BRANCH_IS_NEXT})
+        if (${CLAP_HELPERS_DOWNLOAD_CLAP_BRANCH_IS_NEXT})
            set(cpmbranch "next")
         else()
            set(cpmbranch "main")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,20 +4,27 @@ project(clap-helpers C CXX)
 
 option(CLAP_HELPERS_BUILD_TESTS "Build tests for the CLAP Helper" FALSE)
 option(CLAP_HELPERS_DOWNLOAD_DEPENDENCIES "Resolve CLAP Targets with CPM if not defined" FALSE)
+option(CLAP_HELPERS_DOWNLOAD_CLAP_BRANCH_IS_NEXT "If downloading, downlaod against against 'next' branch" FALSE)
+option(CLAP_HELPERS_NO_CLAP_IS_FATAL "If there is no clap target and no download, emit a fatal error" TRUE)
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE include)
 
 if (NOT TARGET clap)
     if (${CLAP_HELPERS_DOWNLOAD_DEPENDENCIES})
-        message(STATUS "${PROJECT_NAME}: Downloading CLAP using CPM")
+        if (${CLAP_HELPERS_DOWNLOQD_CLAP_BRANCH_IS_NEXT})
+           set(cpmbranch "next")
+        else()
+           set(cpmbranch "main")
+        endif()
+        message(STATUS "${PROJECT_NAME}: Downloading CLAP on branch ${cpmbranch} using CPM")
 
         message(STATUS "${PROJECT_NAME}: including CPM")
         include(cmake/external/CPM.cmake)
         CPMAddPackage(
                 NAME "clap"
                 GITHUB_REPOSITORY "free-audio/clap"
-                GIT_TAG "next"
+                GIT_TAG ${cpmbranch}
                 EXCLUDE_FROM_ALL TRUE
                 DOWNLOAD_ONLY TRUE
                 SOURCE_DIR cpm/clap
@@ -25,7 +32,11 @@ if (NOT TARGET clap)
 
         add_subdirectory(${CMAKE_BINARY_DIR}/cpm/clap)
     else()
-        message(FATAL_ERROR "${PROJECT_NAME}: 'clap' is not a target. Set CLAP_HELPERS_DOWNLOAD_DEPENDENCIES or include clap before clap-helpers")
+        if (${CLAP_HELPERS_NO_CLAP_IS_FATAL})
+            message(FATAL_ERROR "${PROJECT_NAME}: 'clap' is not a target. Set CLAP_HELPERS_DOWNLOAD_DEPENDENCIES or include clap before clap-helpers")
+        else()
+            message(WARNING "${PROJECT_NAME}: 'clap' is not a target. Set CLAP_HELPERS_DOWNLOAD_DEPENDENCIES or include clap before clap-helpers. Build proceeding anyway. Good luck.")
+        endif()
     endif()
 endif()
 target_link_libraries(${PROJECT_NAME} INTERFACE clap)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(clap-helpers C CXX)
 
 option(CLAP_HELPERS_BUILD_TESTS "Build tests for the CLAP Helper" FALSE)
 option(CLAP_HELPERS_DOWNLOAD_DEPENDENCIES "Resolve CLAP Targets with CPM if not defined" FALSE)
-option(CLAP_HELPERS_DOWNLOAD_CLAP_BRANCH_IS_NEXT "If downloading, downlaod against against 'next' branch" FALSE)
+option(CLAP_HELPERS_DOWNLOAD_CLAP_BRANCH_IS_NEXT "If downloading, download against against 'next' branch" FALSE)
 option(CLAP_HELPERS_NO_CLAP_IS_FATAL "If there is no clap target and no download, emit a fatal error" TRUE)
 
 add_library(${PROJECT_NAME} INTERFACE)


### PR DESCRIPTION
Add two cmake options

- CLAP_HELPERS_DOWNLOAD_CLAP_BRANCH_IS_NEXT - does CPM pull next or main?
- CLAP_HELPERS_NO_CLAP_IS_FATAL - if no download and no clap, allow a build to try and struggle on?