### PR TITLE
Missing `;` in version-check.hh

### DIFF
--- a/include/clap/helpers/version-check.hh
+++ b/include/clap/helpers/version-check.hh
@@ -13,9 +13,9 @@
 #include "clap/version.h"
 
 #if CLAP_VERSION_LT(1,2,4)
-static_assert(false, "Clap version must be at least 1.2.4")
+   static_assert(false, "Clap version must be at least 1.2.4");
 #endif
 
 #if CLAP_VERSION_GE(2,0,0)
-   static_assert(false, "Clap version must be at most 1.x")
+   static_assert(false, "Clap version must be at most 1.x");
 #endif


### PR DESCRIPTION
I got the error: `expected ';' after 'static_assert'`.

This is solved by updating to CLAP 1.2.4 anyway, but this gave me a syntax error instead of the helpful message.