### PR TITLE
Set cmake policy CMP0177  in CMakeLists.txt to resolve cmake warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.17)
 cmake_policy(SET CMP0100 NEW)  # handle .hh files
+
+# resolve cmake v3.31 warning expecting install policy CMP0177 to be set
+cmake_policy(SET CMP0177 NEW)
+
 project(clap-helpers C CXX)
 
 option(CLAP_HELPERS_BUILD_TESTS "Build tests for the CLAP Helper" FALSE)


### PR DESCRIPTION
This  change to CMakeLists.txt is intended to resolve a cmake warning regarding cmake install policy CMP0177 which was introduced in cmake  v 3.31.  

The install policy is expected to be set to either OLD or NEW.  

`cmake_policy(SET CMP0177 NEW)`

I referred to the information about CMP0177 on the cmake site here:  [CMP0177](https://cmake.org/cmake/help/latest/policy/CMP0177.html)