### PR TITLE
Fix install command to remove CMP0177 warning that cmake complains about

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,4 +98,4 @@ if (${CLAP_HELPERS_BUILD_TESTS})
 endif()
 
 install(DIRECTORY include DESTINATION ".")
-install(FILES "cmake/clap-helpers-config.cmake" DESTINATION "./lib/cmake/clap-helpers")
+install(FILES "cmake/clap-helpers-config.cmake" DESTINATION "lib/cmake/clap-helpers")


### PR DESCRIPTION
nitpick but it always pops when I run cmake