### PR TITLE
Fix bug causing a misbehaving plugin in the host proxy

### DIFF
--- a/include/clap/helpers/host-proxy.hxx
+++ b/include/clap/helpers/host-proxy.hxx
@@ -174,7 +174,7 @@ namespace clap { namespace helpers {
       if (l == CheckingLevel::None)
          return;
 
-      if (!canUseThreadCheck() || isAudioThread())
+      if (!canUseThreadCheck() || !isAudioThread())
          return;
 
       std::ostringstream msg;


### PR DESCRIPTION
The function `ensureNotAudioThread` should check if the call did not happen on the audio thread but the code checks if the call happened on the audio thread.  

This causes a "misbehaving plugin" event to be raised in the host proxy as soon as the plugin does something like requesting a parameter flush.