### PR TITLE
Fix a regression in ensureNotAudioThread

### DIFF
--- a/include/clap/helpers/host-proxy.hxx
+++ b/include/clap/helpers/host-proxy.hxx
@@ -175,7 +175,7 @@ namespace clap { namespace helpers {
       if (l == CheckingLevel::None)
          return;
 
-      if (!canUseThreadCheck() || isAudioThread())
+      if (!canUseThreadCheck() || !isAudioThread())
          return;
 
       std::ostringstream msg;


### PR DESCRIPTION
in a0f6d257 ensureNotAudioThread was added, but it was missing the !, so it basically was an ensureAudioThread check!